### PR TITLE
Add dummy data

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,21 +1,86 @@
-import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { Component } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  View
+} from "react-native";
+import MockClient from "./MockClient";
 
-const App = () => (
-  <View style={styles.container}>
-    <Text>Open up App.js to start working on your app!</Text>
-    <Text>Changes you make will automatically reload.</Text>
-    <Text>Shake your phone to open the developer menu.</Text>
-  </View>
-);
-
-export default App;
-
+const client = MockClient; // Swap this out for the Contentful client in prod
+const EVENTS_CONTENT_TYPE_SYS_ID = 123; // This will eventually be dynamic, based on the id in Contentful
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center"
+  heroImage: {
+    alignSelf: "center",
+    width: 400,
+    height: 300
   }
 });
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: true
+    };
+  }
+
+  componentDidMount() {
+    return client
+      .getEntries({
+        content_type: EVENTS_CONTENT_TYPE_SYS_ID
+      })
+      .then(responseJson => {
+        this.setState(
+          {
+            isLoading: false,
+            dataSource: responseJson
+          },
+          () => {
+            // do something with new state
+          }
+        );
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      return (
+        <View style={{ flex: 1, paddingTop: 20 }}>
+          <ActivityIndicator />
+        </View>
+      );
+    }
+
+    return (
+      <View style={{ flex: 1, paddingTop: 20 }}>
+        <FlatList
+          data={this.state.dataSource}
+          renderItem={({ item }) => (
+            <View style={{ padding: 10 }}>
+              <Text>{item.name}</Text>
+              <Text>{item.addressName}</Text>
+              <Text>
+                {item.startTime} - {item.endTime}
+              </Text>
+              <Text>
+                {item.lowestPrice} - {item.highestPrice}
+              </Text>
+              <Image
+                style={styles.heroImage}
+                resizeMode="contain"
+                source={{ uri: item.heroImage }}
+              />
+            </View>
+          )}
+          keyExtractor={(item, index) => index}
+        />
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
### Motivation

We want to have some dummy data to play with so that we can style an initial page for the events listing.

We set up a MockClient with the same interface as the client from the contentful npm package which we expect to being at some point in the near future. To request the data and list it in the app, we copy the example from the [React Native Networking docs](https://facebook.github.io/react-native/docs/network.html).

### Screenshot

<img width="621" alt="screen shot 2018-01-13 at 14 14 27" src="https://user-images.githubusercontent.com/5112255/34906804-5ea72022-f86c-11e7-80ed-e1b076e62de3.png">



---------------------

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [ ] Unit tests
* [ ] Build passing

## Pre-merge check-list

* [ ] Code review (At least one :thumbsup:)
* [ ] Tester approved
