### PR TITLE
[WIP] Add service for creating or updating Contentful content types

### DIFF
--- a/contentful/content-types/event.json
+++ b/contentful/content-types/event.json
@@ -1,0 +1,78 @@
+{
+  "id": "event",
+  "name": "Event",
+  "description": "Event description",
+  "displayField": "title",
+  "fields": [
+    {
+      "id": "title",
+      "name": "title",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "addressName",
+      "name": "addressName",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "addressUrl",
+      "name": "addressUrl",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "heroImage",
+      "name": "heroImage",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "startTime",
+      "name": "startTime",
+      "type": "Date",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "endTime",
+      "name": "endTime",
+      "type": "Date",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "body",
+      "name": "youwhatbody",
+      "type": "Text",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}

--- a/contentful/content-types/venue.json
+++ b/contentful/content-types/venue.json
@@ -1,0 +1,48 @@
+{
+  "id": "venue",
+  "name": "Venue",
+  "description": "Venue description",
+  "displayField": "title",
+  "fields": [
+    {
+      "id": "title",
+      "name": "title",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "addressName",
+      "name": "addressName",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "addressUrl",
+      "name": "addressUrl",
+      "type": "Symbol",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    },
+    {
+      "id": "isAccessible",
+      "name": "isAccessible",
+      "type": "Boolean",
+      "localized": false,
+      "required": false,
+      "validations": [],
+      "disabled": false,
+      "omitted": false
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
       "node node_modules/react-native/local-cli/cli.js run-android",
     "test": "jest",
     "precommit": "lint-staged",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "update-contentful": "node services/updateContentTypes.js"
   },
   "dependencies": {
+    "contentful-management": "^4.1.2",
+    "ramda": "^0.25.0",
     "react": "16.2.0",
     "react-native": "0.52.0"
   },

--- a/services/updateContentTypes.js
+++ b/services/updateContentTypes.js
@@ -1,0 +1,51 @@
+const R = require("ramda");
+const contentful = require("contentful-management");
+const eventContentType = require("./../contentful/content-types/event.json");
+const venueContentType = require("./../contentful/content-types/venue.json");
+
+const spaceId = process.env.SPACE_ID;
+const accessToken = process.env.ACCESS_TOKEN;
+const client = contentful.createClient({ accessToken });
+const clientSpace = client.getSpace(spaceId);
+const srcContentTypes = [eventContentType, venueContentType];
+
+const createOrUpdateContentTypes = dstContentTypes => {
+  srcContentTypes.forEach(
+    srcContentType =>
+      dstContentTypes.includes(srcContentType.id)
+        ? updateContentType(srcContentType)
+        : createContentType(srcContentType)
+  );
+};
+
+const updateContentType = srcContentType => {
+  clientSpace
+    .then(space => space.getContentType(srcContentType.id))
+    .then(dstContentType => {
+      dstContentType.name = srcContentType.name;
+      dstContentType.description = srcContentType.description;
+      dstContentType.displayField = srcContentType.displayField;
+      dstContentType.fields = srcContentType.fields;
+      return dstContentType.update();
+    })
+    .then(contentType => contentType.publish())
+    .then(contentType => console.log(`Updated ${srcContentType.id}`));
+};
+
+const createContentType = srcContentType => {
+  clientSpace
+    .then(space =>
+      space.createContentTypeWithId(
+        srcContentType.id,
+        R.omit(["id"], srcContentType)
+      )
+    )
+    .then(contentType => contentType.publish())
+    .then(contentType => console.log(`Created ${srcContentType.id}`));
+};
+
+clientSpace
+  .then(space => space.getContentTypes())
+  .then(response => response.items.map(item => item.sys.id))
+  .then(dstContentTypes => createOrUpdateContentTypes(dstContentTypes))
+  .catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@contentful/axios@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@contentful/axios/-/axios-0.18.0.tgz#576e0e6047411a66971e82d40688a8c795e62f27"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
+
 "@types/node@*":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
@@ -1380,6 +1387,21 @@ content-type@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
+contentful-management@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-4.1.2.tgz#ad78e61d080b4b0f8a35aef6bad650f4fbac5502"
+  dependencies:
+    "@contentful/axios" "^0.18.0"
+    contentful-sdk-core "^5.0.0"
+    lodash "^4.17.4"
+
+contentful-sdk-core@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-5.0.1.tgz#8742b90548310b7088ce43dcd4e87fdb30f9ec03"
+  dependencies:
+    lodash "^4.17.4"
+    qs "^6.5.1"
+
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -2149,6 +2171,12 @@ flat-cache@^1.2.1:
 flow-bin@0.61.0:
   version "0.61.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
+
+follow-redirects@^1.2.5:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.0.tgz#a146a3a5d402201c7a3e6128643f0e336d212b10"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -4304,13 +4332,17 @@ qs@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-4.0.0.tgz#c31d9b74ec27df75e543a86c78728ed8d4623607"
 
+qs@^6.5.1, qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
 
 random-bytes@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Experimenting with using [`contentful-management`](https://www.npmjs.com/package/contentful-management) to create/update content types in Contentful. 

The service lives in `services/updateContentTypes.js` and the JSON for a given content type lives in `contentful/content-types/`. I've got 2 toy examples for the moment, `events` and `venues`.

Features (still WIP):
- Create new content type ✅
- Change name of content type ❓ 
- Change existing field ✅
- Removing a field ❌  (requires ['omitting a field'](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types/content-type-activation) first, see also [here](https://github.com/contentful/contentful-management.js/issues/67), need to look into this more)
- Removing a content type ❓ 

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [ ] Unit tests
* [ ] Build passing

## Pre-merge check-list

* [ ] Code review (At least one :thumbsup:)
* [ ] Tester approved
