### PR TITLE
remove automated checks from template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,7 @@ Before raising a pull request
 
 * [ ] Documentation
 * [ ] Unit tests
-* [ ] Build passing
 
 ## Pre-merge check-list
 
-* [ ] Code review (At least one :thumbsup:)
 * [ ] Tester approved


### PR DESCRIPTION
Removing "Build passing", and "Code review" from PR template as these are enforced by Github

## Pre-flight check-list

Before raising a pull request

* ~~Documentation~~
* ~~Unit tests~~

## Pre-merge check-list

* ~~Tester approved~~
