### PR TITLE
Add extra file exists check to build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,8 +105,11 @@ android {
         targetSdkVersion 22
         versionName "1.0.4"
         Properties props = new Properties()
-        props.load(new FileInputStream(file("../.gradle/gradle.properties")))
-        versionCode props['versionCode'].toInteger()
+        File propertiesFile = new File("../.gradle/gradle.properties");
+        if (propertiesFile.exists()) {
+            props.load(new FileInputStream(propertiesFile))
+            versionCode props['version  Code'].toInteger()
+        }
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }


### PR DESCRIPTION
Looks like we need another check for whether the gradle.properties file exists to enable local development.

## Pre-flight check-list

Before raising a pull request

* ~~Documentation~~
* ~~Unit tests~~

## Pre-merge check-list

* ~~Tester approved~~
