### PR TITLE
Use native app chooser for map links on Android

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,5 +37,8 @@
         "peerDependencies": false
       }
     ]
+  },
+  "settings": {
+    "import/resolver": "react-native"
   }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -42,6 +42,8 @@ module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|we
 module.file_ext=.js
 module.file_ext=.jsx
 module.file_ext=.json
+module.file_ext=.android.js
+module.file_ext=.ios.js
 module.file_ext=.native.js
 
 suppress_type=$FlowIssue

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,6 @@
 [ignore]
 ; We fork some components by platform
-.*/*[.]android.js
+.*/node_modules/.*/*[.]android.js
 
 ; Ignore "BUCK" generated dirs
 <PROJECT_ROOT>/\.buckd/
@@ -44,7 +44,6 @@ module.file_ext=.jsx
 module.file_ext=.json
 module.file_ext=.android.js
 module.file_ext=.ios.js
-module.file_ext=.native.js
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^4.17.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-import-resolver-react-native": "^0.1.0",
     "eslint-plugin-flowtype": "^2.43.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",

--- a/src/screens/EventDetailsScreen/EventMap.js
+++ b/src/screens/EventDetailsScreen/EventMap.js
@@ -2,15 +2,7 @@
 import React from "react";
 import { TouchableOpacity, StyleSheet } from "react-native";
 import MapView, { Marker } from "react-native-maps";
-import { showLocation } from "react-native-map-link";
-
-const onMapPress = (lat, lon, title) => {
-  showLocation({
-    latitude: lat,
-    longitude: lon,
-    title
-  });
-};
+import showLocation from "./openMapLink";
 
 type Props = {
   lat: number,
@@ -21,7 +13,7 @@ type Props = {
 const EventMap = ({ lat, lon, locationName }: Props) => (
   <TouchableOpacity
     style={styles.mapWrapper}
-    onPress={() => onMapPress(lat, lon, locationName)}
+    onPress={() => showLocation(lat, lon, locationName)}
   >
     <MapView
       style={styles.map}

--- a/src/screens/EventDetailsScreen/__mocks__/react-native-map-link.js
+++ b/src/screens/EventDetailsScreen/__mocks__/react-native-map-link.js
@@ -1,0 +1,1 @@
+export const showLocation = jest.fn(() => Promise.resolve()); // eslint-disable-line import/prefer-default-export

--- a/src/screens/EventDetailsScreen/openMapLink.android.js
+++ b/src/screens/EventDetailsScreen/openMapLink.android.js
@@ -1,0 +1,5 @@
+import { Linking } from "react-native";
+
+export default async (lat, lng, label) => {
+  await Linking.openURL(`geo:0,0?q=${lat},${lng}(${label})`);
+};

--- a/src/screens/EventDetailsScreen/openMapLink.android.js
+++ b/src/screens/EventDetailsScreen/openMapLink.android.js
@@ -6,5 +6,7 @@ import { Linking } from "react-native";
  * https://developer.android.com/guide/components/intents-common.html#Maps
  */
 export default async (lat: number, lng: number, label: string) => {
-  await Linking.openURL(`geo:0,0?q=${lat},${lng}(${label})`);
+  await Linking.openURL(
+    `geo:0,0?q=${lat},${lng}(${encodeURIComponent(label)})`
+  );
 };

--- a/src/screens/EventDetailsScreen/openMapLink.android.js
+++ b/src/screens/EventDetailsScreen/openMapLink.android.js
@@ -1,5 +1,10 @@
+// @flow
 import { Linking } from "react-native";
 
-export default async (lat, lng, label) => {
+/**
+ * Opens the default map intent as documented here:
+ * https://developer.android.com/guide/components/intents-common.html#Maps
+ */
+export default async (lat: number, lng: number, label: string) => {
   await Linking.openURL(`geo:0,0?q=${lat},${lng}(${label})`);
 };

--- a/src/screens/EventDetailsScreen/openMapLink.android.test.js
+++ b/src/screens/EventDetailsScreen/openMapLink.android.test.js
@@ -1,0 +1,22 @@
+// @flow
+import { Linking } from "react-native";
+import openMapLink from "./openMapLink.android";
+
+let openURLSpy;
+beforeEach(() => {
+  openURLSpy = jest
+    .spyOn(Linking, "openURL")
+    .mockImplementation(() => Promise.resolve());
+});
+
+it("opens the default Android map intent", async () => {
+  await openMapLink(51.5245918, -0.0881783, "Red Badger");
+
+  expect(openURLSpy).toHaveBeenCalledWith(
+    "geo:0,0?q=51.5245918,-0.0881783(Red%20Badger)"
+  );
+});
+
+afterEach(() => {
+  openURLSpy.mockRestore();
+});

--- a/src/screens/EventDetailsScreen/openMapLink.ios.js
+++ b/src/screens/EventDetailsScreen/openMapLink.ios.js
@@ -1,6 +1,11 @@
+// @flow
 import { showLocation } from "react-native-map-link";
 
-export default async (latitude, longitude, title) => {
+/**
+ * Asks the user to open the location in a few supported
+ * apps (if installed).
+ */
+export default async (latitude: number, longitude: number, title: string) => {
   await showLocation({
     latitude,
     longitude,

--- a/src/screens/EventDetailsScreen/openMapLink.ios.js
+++ b/src/screens/EventDetailsScreen/openMapLink.ios.js
@@ -1,0 +1,9 @@
+import { showLocation } from "react-native-map-link";
+
+export default async (latitude, longitude, title) => {
+  await showLocation({
+    latitude,
+    longitude,
+    title
+  });
+};

--- a/src/screens/EventDetailsScreen/openMapLink.ios.test.js
+++ b/src/screens/EventDetailsScreen/openMapLink.ios.test.js
@@ -1,0 +1,17 @@
+// @flow
+import { showLocation } from "react-native-map-link";
+import openMapLink from "./openMapLink.ios";
+
+it("opens the default Android map intent", async () => {
+  await openMapLink(51.5245918, -0.0881783, "Red Badger");
+
+  expect(showLocation).toHaveBeenCalledWith({
+    latitude: 51.5245918,
+    longitude: -0.0881783,
+    title: "Red Badger"
+  });
+});
+
+afterEach(() => {
+  showLocation.mockRestore();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,12 +2390,26 @@ eslint-config-prettier@^2.9.0:
   dependencies:
     get-stdin "^5.0.1"
 
+eslint-import-resolver-node@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
   dependencies:
     debug "^2.6.9"
     resolve "^1.5.0"
+
+eslint-import-resolver-react-native@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-react-native/-/eslint-import-resolver-react-native-0.1.0.tgz#d67c6a5534c417cb291857aa267f424ae8d280a7"
+  dependencies:
+    eslint-import-resolver-node "^0.2.3"
 
 eslint-module-utils@^2.1.1:
   version "2.1.1"
@@ -6345,7 +6359,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.3.2, resolve@^1.5.0:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION
Android lets you choose your Maps app by default when you open geo coordinates. It is a much nicer experience than the one provided by the library.

## Pre-flight check-list

Before raising a pull request

* [X] Documentation
* [X] Unit tests

## Pre-merge check-list

* [ ] Tester approved
