### PR TITLE
Group events by date

### DIFF
--- a/src/actions/events.js
+++ b/src/actions/events.js
@@ -4,7 +4,7 @@ import {
   getEvents as getEventsCms,
   updateEvents as updateEventsCms
 } from "../integrations/cms";
-import type { Event } from "../integrations/cms";
+import type { Event } from "../data/event";
 import type { StandardAction } from "./";
 
 type EventsActionType =

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import { StyleSheet, SectionList, TouchableOpacity, View } from "react-native";
-import { format, parse } from "date-fns";
+import { format } from "date-fns";
 
 import EventCard from "./EventCard";
 import Text from "./Text";
@@ -32,7 +32,7 @@ const EventList = ({
     keyExtractor={event => event.sys.id}
     sections={events.map(it => ({
       data: it,
-      title: format(parse(it[0].fields.startTime[locale]), "dddd D MMMM")
+      title: format(it[0].fields.startTime[locale], "dddd D MMMM")
     }))}
     renderSectionHeader={({ section }) => (
       <Text type="h2" style={styles.sectionHeader}>

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,12 +1,20 @@
 // @flow
 import React from "react";
-import { View, StyleSheet, FlatList, TouchableOpacity } from "react-native";
+import { StyleSheet, SectionList, TouchableOpacity, View } from "react-native";
+import { format, parse } from "date-fns";
+
 import EventCard from "./EventCard";
-import type { Event } from "../integrations/cms";
+import Text from "./Text";
+import type { EventDays } from "../data/event";
+import {
+  eventListBgColor,
+  eventListHeaderBgColor,
+  eventListHeaderColor
+} from "../constants/colors";
 
 type Props = {
   locale: string,
-  events: Event[],
+  events: EventDays,
   refreshing: boolean,
   onRefresh: () => void,
   onPress: (eventName: string) => void
@@ -19,10 +27,20 @@ const EventList = ({
   onRefresh,
   onPress
 }: Props) => (
-  <FlatList
+  <SectionList
     contentContainerStyle={styles.container}
-    data={events}
     keyExtractor={event => event.sys.id}
+    sections={events.map(it => ({
+      data: it,
+      title: format(parse(it[0].fields.startTime[locale]), "dddd D MMMM")
+    }))}
+    renderSectionHeader={({ section }) => (
+      <Text type="h2" style={styles.sectionHeader}>
+        {section.title}
+      </Text>
+    )}
+    ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+    SectionSeparatorComponent={() => <View style={styles.sectionSeparator} />}
     renderItem={({ item: event }) => (
       <View style={styles.eventListItem}>
         <TouchableOpacity
@@ -39,12 +57,26 @@ const EventList = ({
 );
 
 const styles = StyleSheet.create({
+  itemSeparator: {
+    height: 10
+  },
+  sectionSeparator: {
+    height: 16
+  },
   container: {
-    paddingTop: 10
+    paddingTop: 0,
+    backgroundColor: eventListBgColor
   },
   eventListItem: {
-    paddingHorizontal: 15,
-    paddingBottom: 10
+    paddingHorizontal: 15
+  },
+  sectionHeader: {
+    height: 32,
+    paddingTop: 6,
+    paddingBottom: 2,
+    textAlign: "center",
+    backgroundColor: eventListHeaderBgColor,
+    color: eventListHeaderColor
   }
 });
 

--- a/src/components/EventList.test.js
+++ b/src/components/EventList.test.js
@@ -3,32 +3,58 @@ import { shallow } from "enzyme";
 import EventList from "./EventList";
 
 const events = [
-  {
-    sys: {
-      id: "1",
-      type: "",
-      contentType: { sys: { id: "" } },
-      revision: 1
+  [
+    {
+      sys: {
+        id: "1",
+        type: "",
+        contentType: { sys: { id: "" } },
+        revision: 1
+      },
+      fields: {
+        name: {
+          "en-GB": "some event"
+        },
+        startTime: {
+          "en-GB": "2018-07-10T00:00"
+        }
+      }
     },
-    fields: {
-      name: {
-        "en-GB": "some event"
+    {
+      sys: {
+        id: "2",
+        type: "",
+        contentType: { sys: { id: "" } },
+        revision: 1
+      },
+      fields: {
+        name: {
+          "en-GB": "some other"
+        },
+        startTime: {
+          "en-GB": "2018-07-10T00:00"
+        }
       }
     }
-  },
-  {
-    sys: {
-      id: "2",
-      type: "",
-      contentType: { sys: { id: "" } },
-      revision: 1
-    },
-    fields: {
-      name: {
-        "en-GB": "some other"
+  ],
+  [
+    {
+      sys: {
+        id: "2",
+        type: "",
+        contentType: { sys: { id: "" } },
+        revision: 1
+      },
+      fields: {
+        name: {
+          "en-GB": "some other"
+        },
+        startTime: {
+          "en-GB": "2018-07-11T00:00"
+        }
       }
     }
-  }
+  ]
 ];
 
 it("renders correctly", () => {

--- a/src/components/__snapshots__/EventList.test.js.snap
+++ b/src/components/__snapshots__/EventList.test.js.snap
@@ -1,61 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<FlatList
+<SectionList
+  ItemSeparatorComponent={[Function]}
+  SectionSeparatorComponent={[Function]}
   contentContainerStyle={
     Object {
-      "paddingTop": 10,
+      "backgroundColor": "rgb(226, 226, 226)",
+      "paddingTop": 0,
     }
   }
-  data={
-    Array [
-      Object {
-        "fields": Object {
-          "name": Object {
-            "en-GB": "some event",
-          },
-        },
-        "sys": Object {
-          "contentType": Object {
-            "sys": Object {
-              "id": "",
-            },
-          },
-          "id": "1",
-          "revision": 1,
-          "type": "",
-        },
-      },
-      Object {
-        "fields": Object {
-          "name": Object {
-            "en-GB": "some other",
-          },
-        },
-        "sys": Object {
-          "contentType": Object {
-            "sys": Object {
-              "id": "",
-            },
-          },
-          "id": "2",
-          "revision": 1,
-          "type": "",
-        },
-      },
-    ]
-  }
+  data={Array []}
   disableVirtualization={false}
   horizontal={false}
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
-  numColumns={1}
   onEndReachedThreshold={2}
   onRefresh={[Function]}
   refreshing={false}
   renderItem={[Function]}
+  renderSectionHeader={[Function]}
   scrollEventThrottle={50}
+  sections={
+    Array [
+      Object {
+        "data": Array [
+          Object {
+            "fields": Object {
+              "name": Object {
+                "en-GB": "some event",
+              },
+              "startTime": Object {
+                "en-GB": "2018-07-10T00:00",
+              },
+            },
+            "sys": Object {
+              "contentType": Object {
+                "sys": Object {
+                  "id": "",
+                },
+              },
+              "id": "1",
+              "revision": 1,
+              "type": "",
+            },
+          },
+          Object {
+            "fields": Object {
+              "name": Object {
+                "en-GB": "some other",
+              },
+              "startTime": Object {
+                "en-GB": "2018-07-10T00:00",
+              },
+            },
+            "sys": Object {
+              "contentType": Object {
+                "sys": Object {
+                  "id": "",
+                },
+              },
+              "id": "2",
+              "revision": 1,
+              "type": "",
+            },
+          },
+        ],
+        "title": "Tuesday 10 July",
+      },
+      Object {
+        "data": Array [
+          Object {
+            "fields": Object {
+              "name": Object {
+                "en-GB": "some other",
+              },
+              "startTime": Object {
+                "en-GB": "2018-07-11T00:00",
+              },
+            },
+            "sys": Object {
+              "contentType": Object {
+                "sys": Object {
+                  "id": "",
+                },
+              },
+              "id": "2",
+              "revision": 1,
+              "type": "",
+            },
+          },
+        ],
+        "title": "Wednesday 11 July",
+      },
+    ]
+  }
+  stickySectionHeadersEnabled={true}
   updateCellsBatchingPeriod={50}
   windowSize={21}
 />

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -8,6 +8,12 @@ export const textColor = "#272727";
 export const filterButtonColor = "#5C5C5C";
 export const filterButtontextColor = "#ADADAD";
 
+// EVENT LIST
+
+export const eventListBgColor = "rgb(226, 226, 226)";
+export const eventListHeaderBgColor = "rgb(216, 216, 216)";
+export const eventListHeaderColor = "rgb(51, 51, 51)";
+
 // EVENT DETAILS
 export const eventDetailsBgColor = "#FFF";
 export const eventDetailsHeaderBgColor = "#F2F2F2";

--- a/src/data/event.js
+++ b/src/data/event.js
@@ -1,0 +1,32 @@
+// @flow
+export type Event = {
+  sys: {
+    id: string,
+    type: string,
+    contentType: {
+      sys: {
+        id: string
+      }
+    },
+    revision: number
+  },
+  fields: {
+    name: { [string]: string },
+    eventCategories: { [string]: string[] },
+    startTime: { [string]: string },
+    endTime: { [string]: string },
+    location: { [string]: { lat: number, lon: number } },
+    locationName: { [string]: string },
+    eventPriceLow: { [string]: number },
+    eventPriceHigh: { [string]: number },
+    accessibilityOptions: { [string]: string[] },
+    eventDescription: { [string]: string },
+    accessibilityDetails: { [string]: string },
+    email: { [string]: string },
+    phone: { [string]: string },
+    ticketingUrl: { [string]: string },
+    venueDetails: { [string]: string[] }
+  }
+};
+
+export type EventDays = Event[][];

--- a/src/integrations/cms.js
+++ b/src/integrations/cms.js
@@ -5,35 +5,8 @@ import Config from "react-native-config";
 import { createClient } from "contentful/dist/contentful.browser.min";
 import { saveEvents, loadEvents } from "./storage";
 
-export type Event = {
-  sys: {
-    id: string,
-    type: string,
-    contentType: {
-      sys: {
-        id: string
-      }
-    },
-    revision: number
-  },
-  fields: {
-    name: { [string]: string },
-    eventCategories: { [string]: string[] },
-    startTime: { [string]: string },
-    endTime: { [string]: string },
-    location: { [string]: { lat: number, lon: number } },
-    locationName: { [string]: string },
-    eventPriceLow: { [string]: number },
-    eventPriceHigh: { [string]: number },
-    accessibilityOptions: { [string]: string[] },
-    eventDescription: { [string]: string },
-    accessibilityDetails: { [string]: string },
-    email: { [string]: string },
-    phone: { [string]: string },
-    ticketingUrl: { [string]: string },
-    venueDetails: { [string]: string[] }
-  }
-};
+import type { Event } from "../data/event";
+
 export type Deletion = {
   sys: {
     id: string

--- a/src/integrations/storage.js
+++ b/src/integrations/storage.js
@@ -1,7 +1,8 @@
 // @flow
 
 import { AsyncStorage } from "react-native";
-import type { Event, Deletion } from "./cms";
+import type { Deletion } from "./cms";
+import type { Event } from "../data/event";
 
 type EventsData = {
   events: Event[],

--- a/src/reducers/events.js
+++ b/src/reducers/events.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Reducer } from "redux";
-import type { Event } from "../integrations/cms";
+import type { Event } from "../data/event";
 import type { EventsAction } from "../actions/events";
 
 export type State = {

--- a/src/screens/EventDetailsScreen/component.js
+++ b/src/screens/EventDetailsScreen/component.js
@@ -16,7 +16,7 @@ import {
 } from "../../constants/colors";
 import text from "../../constants/text";
 import strings from "../../constants/strings";
-import type { Event } from "../../integrations/cms";
+import type { Event } from "../../data/event";
 
 const locale = "en-GB";
 

--- a/src/screens/EventDetailsScreen/index.js
+++ b/src/screens/EventDetailsScreen/index.js
@@ -2,7 +2,7 @@
 import { connect } from "react-redux";
 import type { Connector, MapStateToProps } from "react-redux";
 import type { NavigationScreenProp } from "react-navigation";
-import type { Event } from "../../integrations/cms";
+import type { Event } from "../../data/event";
 import type { State } from "../../reducers";
 import { selectEventById } from "../../selectors/events";
 import Component from "./component";

--- a/src/screens/EventsScreen/component.js
+++ b/src/screens/EventsScreen/component.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
-import type { Event } from "../../integrations/cms";
+import type { EventDays } from "../../data/event";
 import EventList from "../../components/EventList";
 import FilterHeader from "../../components/FilterHeader";
 import { bgColor } from "../../constants/colors";
@@ -12,7 +12,7 @@ const locale = "en-GB";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,
-  events: Event[],
+  events: EventDays,
   loading: boolean,
   refreshing: boolean,
   updateEvents: () => Promise<void>
@@ -27,18 +27,21 @@ class EventsScreen extends PureComponent<Props> {
     return (
       <View style={styles.container}>
         <FilterHeader />
-        {this.props.loading && <Text>Loading...</Text>}
-        <EventList
-          locale={locale}
-          events={this.props.events}
-          refreshing={this.props.refreshing}
-          onRefresh={() => {
-            this.props.updateEvents();
-          }}
-          onPress={(eventId: string) => {
-            this.props.navigation.navigate(EVENT_DETAILS, { eventId });
-          }}
-        />
+        {this.props.loading ? (
+          <Text>Loading...</Text>
+        ) : (
+          <EventList
+            locale={locale}
+            events={this.props.events}
+            refreshing={this.props.refreshing}
+            onRefresh={() => {
+              this.props.updateEvents();
+            }}
+            onPress={(eventId: string) => {
+              this.props.navigation.navigate(EVENT_DETAILS, { eventId });
+            }}
+          />
+        )}
       </View>
     );
   }

--- a/src/screens/EventsScreen/index.js
+++ b/src/screens/EventsScreen/index.js
@@ -2,12 +2,12 @@
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
-import type { Event } from "../../integrations/cms";
+import type { EventDays } from "../../data/event";
 import { updateEvents } from "../../actions/events";
 import {
-  selectEvents,
   selectEventsLoading,
-  selectEventsRefreshing
+  selectEventsRefreshing,
+  selectEventsGroupedByDay
 } from "../../selectors/events";
 import Component from "./component";
 
@@ -16,14 +16,14 @@ type OwnProps = {
 };
 
 type Props = {
-  events: Event[],
+  events: EventDays,
   loading: boolean,
   refreshing: boolean,
   updateEvents: () => Promise<void>
 } & OwnProps;
 
 const mapStateToProps = state => ({
-  events: selectEvents(state),
+  events: selectEventsGroupedByDay(state),
   loading: selectEventsLoading(state),
   refreshing: selectEventsRefreshing(state)
 });

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -1,5 +1,38 @@
 // @flow
+import { parse as parseDate, differenceInCalendarDays } from "date-fns";
 import type { State } from "../reducers";
+import type { Event, EventDays } from "../data/event";
+
+const locale = "en-GB";
+
+const groupByStartTime = (events: Event[]): EventDays => {
+  const sections = events
+    .sort((a: Event, b: Event) => {
+      const diff =
+        parseDate(a.fields.startTime[locale]) -
+        parseDate(b.fields.startTime[locale]);
+
+      return diff / Math.abs(diff);
+    })
+    .reduce(
+      ({ days, buffer }, event) => {
+        if (buffer.length < 1) return { days, buffer: [event] };
+
+        const previous: Event = buffer[buffer.length - 1];
+        const diff = differenceInCalendarDays(
+          parseDate(previous.fields.startTime[locale]),
+          parseDate(event.fields.startTime[locale])
+        );
+
+        if (diff !== 0) return { days: [...days, buffer], buffer: [event] };
+
+        return { days, buffer: [...buffer, event] };
+      },
+      { days: [], buffer: [] }
+    );
+
+  return [...sections.days, sections.buffer];
+};
 
 const getEventsState = (state: State) => state.events;
 
@@ -11,3 +44,6 @@ export const selectEventsRefreshing = (state: State) =>
 
 export const selectEventById = (state: State, id: String) =>
   selectEvents(state).find(event => event.sys.id === id);
+
+export const selectEventsGroupedByDay = (state: State): EventDays =>
+  groupByStartTime(getEventsState(state).events);

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -7,13 +7,11 @@ const locale = "en-GB";
 
 const groupByStartTime = (events: Event[]): EventDays => {
   const sections = events
-    .sort((a: Event, b: Event) => {
-      const diff =
+    .sort(
+      (a: Event, b: Event) =>
         parseDate(a.fields.startTime[locale]) -
-        parseDate(b.fields.startTime[locale]);
-
-      return diff / Math.abs(diff);
-    })
+        parseDate(b.fields.startTime[locale])
+    )
     .reduce(
       ({ days, buffer }, event) => {
         if (buffer.length < 1) return { days, buffer: [event] };

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -1,7 +1,8 @@
 import {
   selectEvents,
   selectEventsLoading,
-  selectEventsRefreshing
+  selectEventsRefreshing,
+  selectEventsGroupedByDay
 } from "./events";
 
 describe("selectEvents", () => {
@@ -46,5 +47,112 @@ describe("selectEventsRefreshing", () => {
     const selected = selectEventsRefreshing(state);
 
     expect(selected).toBe(refreshing);
+  });
+});
+
+describe("selectEventsGroupedByDay", () => {
+  it("separates two individual events by day and sorts", () => {
+    const state = {
+      events: {
+        events: [
+          { fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } }
+        ]
+      }
+    };
+
+    const expected = [
+      [{ fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } }],
+      [{ fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } } }]
+    ];
+    const actual = selectEventsGroupedByDay(state);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("leaves two events on the same day together", () => {
+    const state = {
+      events: {
+        events: [
+          { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-01T10:00:00" } } }
+        ]
+      }
+    };
+
+    const expected = [
+      [
+        { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-01T10:00:00" } } }
+      ]
+    ];
+    const actual = selectEventsGroupedByDay(state);
+
+    expect(actual).toEqual(expected);
+  });
+  it("makes two groups", () => {
+    const state = {
+      events: {
+        events: [
+          { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-02T02:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-02T03:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } }
+        ]
+      }
+    };
+
+    const expected = [
+      [
+        { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } }
+      ],
+      [
+        { fields: { startTime: { "en-GB": "2018-08-02T02:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-02T03:00:00" } } }
+      ]
+    ];
+    const actual = selectEventsGroupedByDay(state);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("makes multiple groups", () => {
+    const state = {
+      events: {
+        events: [
+          { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-02T02:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-02T03:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-05T02:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-04T00:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-03T03:00:00" } } },
+          { fields: { startTime: { "en-GB": "2018-08-04T02:00:00" } } }
+        ]
+      }
+    };
+
+    const expected = [
+      [
+        { fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-01T02:00:00" } } }
+      ],
+      [
+        { fields: { startTime: { "en-GB": "2018-08-02T02:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-02T03:00:00" } } }
+      ],
+      [{ fields: { startTime: { "en-GB": "2018-08-03T03:00:00" } } }],
+      [
+        { fields: { startTime: { "en-GB": "2018-08-04T00:00:00" } } },
+        { fields: { startTime: { "en-GB": "2018-08-04T02:00:00" } } }
+      ],
+      [{ fields: { startTime: { "en-GB": "2018-08-05T02:00:00" } } }]
+    ];
+    const actual = selectEventsGroupedByDay(state);
+
+    expect(actual).toEqual(expected);
   });
 });


### PR DESCRIPTION
![](https://media.giphy.com/media/g3xeQPxe9HAWI/giphy.gif)

Add grouping of events by date. I've implemented the data processing as a new selector.

I've also moved the Event type out into a separate file, which seems a lot cleaner, as we're working with it all over the place and pulling it in from the CMS integration module seems a bit wrong. 

I put that module into a `data` folder, which can be a sort of domain model section for functions that operate on the domain entities and the associated types.

## Screenshot

![grouping](https://user-images.githubusercontent.com/1517854/37246033-b3d83fe6-2499-11e8-97b5-bd84f87ee8a7.png)


## Pre-flight check-list

Before raising a pull request

* [x] Documentation
* [x] Unit tests

## Pre-merge check-list

* [ ] Tester approved
