### PR TITLE
Update React Native to 0.54.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "contentful": "^5.0.5",
     "date-fns": "^1.29.0",
     "react": "16.2.0",
-    "react-native": "0.54.0",
+    "react-native": "0.54.2",
     "react-native-calendars": "^1.17.4",
     "react-native-config": "^0.11.5",
     "react-native-easy-markdown": "^1.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5984,9 +5984,9 @@ react-native-version@^2.4.1:
     pbxproj-dom "^1.0.11"
     plist "^2.1.0"
 
-react-native@0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.54.0.tgz#1582cc2b2a639d46e39c44bcc50e051d0061820a"
+react-native@0.54.2:
+  version "0.54.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.54.2.tgz#73786e7bf3f80b0b060ca0bfe5b192f9c2f253da"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"


### PR DESCRIPTION
This gets rid of the yellow warnings.