### PR TITLE
Treat empty time filter as 'Any time'

### DIFF
--- a/src/actions/event-filters.js
+++ b/src/actions/event-filters.js
@@ -5,7 +5,7 @@ import type { StandardAction } from "./";
 type EventFiltersActionType = "UPDATE_EVENT_FILTERS";
 type EventFiltersPayload = {
   date?: ?DateOrDateRange,
-  time?: Time[]
+  time?: Set<Time>
 };
 
 export type EventFiltersAction = StandardAction<

--- a/src/components/ConnectedFilterHeader.js
+++ b/src/components/ConnectedFilterHeader.js
@@ -9,7 +9,7 @@ type OwnProps = {};
 
 type Props = {
   dateFilter: ?DateOrDateRange,
-  timeFilter: Time[]
+  timeFilter: Set<Time>
 } & OwnProps;
 
 const mapStateToProps = state => ({

--- a/src/components/ConnectedTimeFilterDialog.js
+++ b/src/components/ConnectedTimeFilterDialog.js
@@ -26,14 +26,16 @@ type Props = {
 const mapStateToProps = state => ({
   applyButtonText: text.filterPickerApply(selectFilteredEvents(state).length),
   options: OPTIONS.map(option => text.time[option]),
-  selectedIndexes: selectTimeFilter(state).map(time => OPTIONS.indexOf(time)),
+  selectedIndexes: Array.from(selectTimeFilter(state)).map(time =>
+    OPTIONS.indexOf(time)
+  ),
   title: text.filterTimePickerTitle
 });
 
 const mapDispatchToProps = {
   onChange: selectedIndexes =>
     updateEventFilters({
-      time: selectedIndexes.map(index => OPTIONS[index])
+      time: new Set(selectedIndexes.map(index => OPTIONS[index]))
     })
 };
 

--- a/src/components/FilterHeader.js
+++ b/src/components/FilterHeader.js
@@ -17,7 +17,7 @@ import { formatDateRange } from "../data/formatters";
 
 type Props = {
   dateFilter: ?DateOrDateRange,
-  timeFilter: Time[]
+  timeFilter: Set<Time>
 };
 
 type State = {
@@ -52,9 +52,10 @@ class FilterHeader extends React.PureComponent<Props, State> {
     const formattedDateFilter = dateFilter
       ? formatDateRange(dateFilter)
       : text.anyDay;
+    const timeArray = Array.from(timeFilter);
     const formattedTimeFilter =
-      timeFilter.length < 3
-        ? timeFilter.map(time => text.time[time]).join(", ")
+      timeArray.length > 0 && timeArray.length < 3
+        ? timeArray.map(time => text.time[time]).join(", ")
         : text.anyTime;
 
     return (

--- a/src/components/FilterHeader.test.js
+++ b/src/components/FilterHeader.test.js
@@ -8,9 +8,9 @@ import TimeFilterDialog from "./ConnectedTimeFilterDialog";
 import type { DateOrDateRange, Time } from "../data/date-time";
 
 const render = (
-  props: { dateFilter: ?DateOrDateRange, timeFilter: Time[] } = {
+  props: { dateFilter: ?DateOrDateRange, timeFilter: Set<Time> } = {
     dateFilter: null,
-    timeFilter: ["morning"]
+    timeFilter: new Set(["morning"])
   }
 ) => shallow(<FilterHeader {...props} />);
 
@@ -18,7 +18,15 @@ describe("renders correctly", () => {
   it("with any date and any time", () => {
     const output = render({
       dateFilter: null,
-      timeFilter: ["morning", "afternoon", "evening"]
+      timeFilter: new Set(["morning", "afternoon", "evening"])
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  it("with any date and any time (empty time set)", () => {
+    const output = render({
+      dateFilter: null,
+      timeFilter: new Set()
     });
     expect(output).toMatchSnapshot();
   });
@@ -26,7 +34,7 @@ describe("renders correctly", () => {
   it("with single date and single time", () => {
     const output = render({
       dateFilter: "2018-02-02",
-      timeFilter: ["afternoon"]
+      timeFilter: new Set(["afternoon"])
     });
     expect(output).toMatchSnapshot();
   });
@@ -37,7 +45,7 @@ describe("renders correctly", () => {
         startDate: "2018-02-02",
         endDate: "2018-02-03"
       },
-      timeFilter: ["morning", "afternoon"]
+      timeFilter: new Set(["morning", "afternoon"])
     });
     expect(output).toMatchSnapshot();
   });

--- a/src/components/__snapshots__/FilterHeader.test.js.snap
+++ b/src/components/__snapshots__/FilterHeader.test.js.snap
@@ -1,5 +1,144 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders correctly with any date and any time (empty time set) 1`] = `
+<withOrientation
+  forceInset={
+    Object {
+      "top": "always",
+    }
+  }
+  style={
+    Object {
+      "backgroundColor": "#A5A5A5",
+    }
+  }
+>
+  <StatusBar
+    animated={true}
+    barStyle="light-content"
+    showHideTransition="fade"
+  />
+  <View
+    style={
+      Object {
+        "paddingBottom": 12,
+        "paddingTop": 16,
+      }
+    }
+    testID="filter-header"
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "#545454",
+            "borderRadius": 4,
+            "flex": 1,
+            "height": 44,
+            "justifyContent": "center",
+            "marginLeft": 8,
+            "paddingHorizontal": 12,
+          }
+        }
+      >
+        <Text
+          markdown={false}
+          style={
+            Object {
+              "color": "#FFFFFF",
+            }
+          }
+          type="h2"
+        >
+          I'm interested in...
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#545454",
+            "borderRadius": 25,
+            "height": 52,
+            "justifyContent": "flex-end",
+            "marginHorizontal": 12,
+            "width": 52,
+          }
+        }
+      >
+        <Text
+          markdown={false}
+          style={
+            Object {
+              "color": "#FFFFFF",
+              "fontFamily": "Poppins-Bold",
+              "fontSize": 14,
+              "paddingBottom": 6,
+            }
+          }
+          type="text"
+        >
+          Map
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "marginTop": 8,
+        }
+      }
+    >
+      <FilterHeaderButton
+        onPress={[Function]}
+        style={
+          Object {
+            "marginLeft": 8,
+          }
+        }
+        text="Any day"
+      />
+      <FilterHeaderButton
+        onPress={[Function]}
+        style={
+          Object {
+            "marginLeft": 8,
+          }
+        }
+        text="Any time"
+      />
+      <FilterHeaderButton
+        onPress={[Function]}
+        style={
+          Object {
+            "marginLeft": 8,
+          }
+        }
+        text="Filters"
+      />
+    </View>
+  </View>
+  <Connect(DateRangePickerDialog)
+    onApply={[Function]}
+    onCancel={[Function]}
+    visible={false}
+  />
+  <Connect(MultiSelectDialog)
+    onApply={[Function]}
+    onCancel={[Function]}
+    visible={false}
+  />
+</withOrientation>
+`;
+
 exports[`renders correctly with any date and any time 1`] = `
 <withOrientation
   forceInset={

--- a/src/reducers/__snapshots__/event-filters.test.js.snap
+++ b/src/reducers/__snapshots__/event-filters.test.js.snap
@@ -3,10 +3,6 @@
 exports[`Event filters reducer initialises with default state 1`] = `
 Object {
   "date": null,
-  "time": Array [
-    "morning",
-    "afternoon",
-    "evening",
-  ],
+  "time": Set {},
 }
 `;

--- a/src/reducers/event-filters.js
+++ b/src/reducers/event-filters.js
@@ -5,12 +5,12 @@ import type { EventFiltersAction } from "../actions/event-filters";
 
 export type State = {
   date: ?DateOrDateRange,
-  time: Time[]
+  time: Set<Time>
 };
 
 const defaultState = {
   date: null,
-  time: ["morning", "afternoon", "evening"]
+  time: new Set()
 };
 
 const eventFilters: Reducer<State, EventFiltersAction> = (

--- a/src/reducers/event-filters.test.js
+++ b/src/reducers/event-filters.test.js
@@ -12,7 +12,7 @@ describe("Event filters reducer", () => {
   it("updates state with filters from payload for UPDATE_EVENT_FILTERS action", () => {
     const initialState = {
       date: null,
-      time: ["morning", "afternoon", "evening"]
+      time: new Set()
     };
     const state = reducer(initialState, {
       type: "UPDATE_EVENT_FILTERS",

--- a/src/selectors/basic-event-filters.js
+++ b/src/selectors/basic-event-filters.js
@@ -24,9 +24,15 @@ export const buildDateRangeFilter = (date: DateRange) => (event: Event) =>
     event.fields.endTime[locale]
   );
 
-export const buildTimeFilter = (time: Time[]) => (event: Event) =>
-  (time.includes("morning") && getHours(event.fields.startTime[locale]) < 12) ||
-  (time.includes("afternoon") &&
-    (getHours(event.fields.startTime[locale]) < 18 &&
-      getHours(event.fields.endTime[locale]) > 12)) ||
-  (time.includes("evening") && getHours(event.fields.endTime[locale]) >= 18);
+export const buildTimeFilter = (time: Time) => {
+  if (time === "morning") {
+    return (event: Event) => getHours(event.fields.startTime[locale]) < 12;
+  } else if (time === "afternoon") {
+    return (event: Event) =>
+      getHours(event.fields.startTime[locale]) < 18 &&
+      getHours(event.fields.endTime[locale]) > 12;
+  }
+
+  // time === "evening"
+  return (event: Event) => getHours(event.fields.endTime[locale]) >= 18;
+};

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -78,22 +78,17 @@ describe("buildTimeFilter", () => {
   const event = buildEvent("2018-08-02T08:00:00", "2018-08-02T15:00:00");
 
   it("checks for morning", () => {
-    const filter = buildTimeFilter(["morning"]);
+    const filter = buildTimeFilter("morning");
     expect(filter(event)).toBe(true);
   });
 
   it("checks for afternoon", () => {
-    const filter = buildTimeFilter(["afternoon"]);
+    const filter = buildTimeFilter("afternoon");
     expect(filter(event)).toBe(true);
   });
 
   it("checks for evening", () => {
-    const filter = buildTimeFilter(["evening"]);
+    const filter = buildTimeFilter("evening");
     expect(filter(event)).toBe(false);
-  });
-
-  it("combines multiple times with OR", () => {
-    const filter = buildTimeFilter(["morning", "evening"]);
-    expect(filter(event)).toBe(true);
   });
 });

--- a/src/selectors/event-filters.js
+++ b/src/selectors/event-filters.js
@@ -5,7 +5,7 @@ import {
   buildTimeFilter
 } from "./basic-event-filters";
 import type { Event } from "../data/event";
-import type { DateOrDateRange } from "../data/date-time";
+import type { DateOrDateRange, Time } from "../data/date-time";
 import type { State } from "../reducers";
 
 const getEventFiltersState = (state: State) => state.eventFilters;
@@ -18,12 +18,21 @@ export const selectTimeFilter = (state: State) =>
 const buildDateOrDateRangeFilter = (date: DateOrDateRange) =>
   typeof date === "string" ? buildDateFilter(date) : buildDateRangeFilter(date);
 
+const buildTimesFilter = (times: Time[]) => {
+  const filters = times.map(time => buildTimeFilter(time));
+  return (event: Event) => filters.some(filter => filter(event));
+};
+
 export const buildEventFilter = (state: State) => {
   const { date, time } = getEventFiltersState(state);
+  const timeArray = Array.from(time);
   const dateFilter: (event: Event) => boolean = date
     ? buildDateOrDateRangeFilter(date)
     : () => true;
-  const timeFilter = buildTimeFilter(time);
+  const timeFilter: (event: Event) => boolean =
+    timeArray.length > 0 && timeArray.length < 3
+      ? buildTimesFilter(timeArray)
+      : () => true;
 
   return (event: Event) => dateFilter(event) && timeFilter(event);
 };

--- a/src/selectors/event-filters.test.js
+++ b/src/selectors/event-filters.test.js
@@ -9,6 +9,7 @@ import {
   selectTimeFilter,
   buildEventFilter
 } from "./event-filters";
+import type { State as EventFiltersState } from "../reducers/event-filters";
 import type { Event } from "../data/event";
 
 jest.mock("./basic-event-filters");
@@ -16,7 +17,7 @@ const untypedBuildDateFilter: any = buildDateFilter;
 const untypedBuildDateRangeFilter: any = buildDateRangeFilter;
 const untypedBuildTimeFilter: any = buildTimeFilter;
 
-const buildState = ({ date, time }) => ({
+const buildState = ({ date, time }: EventFiltersState) => ({
   events: {
     events: [],
     loading: false,
@@ -40,7 +41,7 @@ describe("selectDateFilter", () => {
   it("returns the date part of the eventFilters", () => {
     const state = buildState({
       date: "2018-01-01",
-      time: ["morning"]
+      time: new Set(["morning"])
     });
 
     const actual = selectDateFilter(state);
@@ -50,13 +51,14 @@ describe("selectDateFilter", () => {
 
 describe("selectTimeFilter", () => {
   it("returns the time part of the eventFilters", () => {
+    const time = new Set(["morning"]);
     const state = buildState({
       date: "2018-01-01",
-      time: ["morning"]
+      time
     });
 
     const actual = selectTimeFilter(state);
-    expect(actual).toEqual(["morning"]);
+    expect(actual).toBe(time);
   });
 });
 
@@ -68,7 +70,7 @@ describe("buildEventFilter", () => {
 
     const state = buildState({
       date: null,
-      time: ["morning", "afternoon", "evening"]
+      time: new Set(["morning", "afternoon", "evening"])
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(true);
@@ -82,7 +84,7 @@ describe("buildEventFilter", () => {
 
     const state = buildState({
       date: "2018-08-02",
-      time: ["morning", "afternoon", "evening"]
+      time: new Set(["morning", "afternoon", "evening"])
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(true);
@@ -101,7 +103,7 @@ describe("buildEventFilter", () => {
         startDate: "2018-08-02",
         endDate: "2018-08-03"
       },
-      time: ["morning", "afternoon", "evening"]
+      time: new Set(["morning", "afternoon", "evening"])
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(true);
@@ -111,39 +113,60 @@ describe("buildEventFilter", () => {
     );
   });
 
-  it("builds time filter", () => {
-    untypedBuildTimeFilter.mockReturnValue(() => true);
-
+  it("builds always truthy time filter when time array is empty", () => {
     const state = buildState({
       date: null,
-      time: ["morning", "afternoon", "evening"]
+      time: new Set()
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(true);
-    expect(untypedBuildTimeFilter).toHaveBeenCalledWith(
-      state.eventFilters.time
-    );
+    expect(untypedBuildTimeFilter).not.toHaveBeenCalled();
   });
 
-  it("builds filter, which returns false time filter return false", () => {
+  it("builds always truthy time filter when time array contains all possible values", () => {
+    const state = buildState({
+      date: null,
+      time: new Set(["morning", "afternoon", "evening"])
+    });
+    const filter = buildEventFilter(state);
+    expect(filter(event)).toBe(true);
+    expect(untypedBuildTimeFilter).not.toHaveBeenCalled();
+  });
+
+  it("builds time filter, which returns true when one of the times match", () => {
+    untypedBuildTimeFilter
+      .mockReturnValue(() => true)
+      .mockReturnValueOnce(() => false);
+
+    const state = buildState({
+      date: null,
+      time: new Set(["morning", "evening"])
+    });
+    const filter = buildEventFilter(state);
+    expect(filter(event)).toBe(true);
+    expect(untypedBuildTimeFilter).toHaveBeenCalledWith("morning");
+    expect(untypedBuildTimeFilter).toHaveBeenCalledWith("evening");
+  });
+
+  it("builds filter, which returns false when time filter return false", () => {
     untypedBuildTimeFilter.mockReturnValue(() => false);
     untypedBuildDateFilter.mockReturnValue(() => true);
 
     const state = buildState({
       date: "2018-02-01",
-      time: ["morning", "afternoon", "evening"]
+      time: new Set(["morning"])
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(false);
   });
 
-  it("builds filter, which returns false date filter return false", () => {
+  it("builds filter, which returns false when date filter return false", () => {
     untypedBuildTimeFilter.mockReturnValue(() => true);
     untypedBuildDateFilter.mockReturnValue(() => false);
 
     const state = buildState({
       date: "2018-02-01",
-      time: ["morning", "afternoon", "evening"]
+      time: new Set(["morning", "afternoon", "evening"])
     });
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(false);


### PR DESCRIPTION
I discussed with Cellyn, that having no time selected should be treated as "Any time". This also makes it consistent with the date filter, where having no date selected means "Any date".

![image](https://user-images.githubusercontent.com/3579251/37565506-7fded4a2-2aa2-11e8-93bd-e053415853fd.png)

In addition I converted the time filter to a `Set`. I think this is more correct than an array, since you can only select a time once.