### PR TITLE
Add component to handle horizontal padding

### DIFF
--- a/src/components/ContentPadding.js
+++ b/src/components/ContentPadding.js
@@ -1,0 +1,20 @@
+// @flow
+import React from "react";
+import { View, Dimensions } from "react-native";
+import type { Node } from "react";
+import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
+
+type Props = {
+  children: Node,
+  style?: StyleObj
+};
+
+const ContentPadding = ({ children, style }: Props) => {
+  const paddingHorizontal = Dimensions.get("window").width >= 360 ? 16 : 8;
+  return <View style={[{ paddingHorizontal }, style]}>{children}</View>;
+};
+ContentPadding.defaultProps = {
+  style: {}
+};
+
+export default ContentPadding;

--- a/src/components/ContentPadding.test.js
+++ b/src/components/ContentPadding.test.js
@@ -1,0 +1,49 @@
+// @flow
+import React from "react";
+import { Text, Dimensions } from "react-native";
+import { shallow } from "enzyme";
+import ContentPadding from "./ContentPadding";
+
+describe("ContentPadding", () => {
+  it("renders correctly", () => {
+    expect(
+      shallow(
+        <ContentPadding>
+          <Text>Something</Text>
+        </ContentPadding>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("adds small padding for small devices", () => {
+    const dimensionsMock = jest
+      .spyOn(Dimensions, "get")
+      .mockImplementation(() => ({ width: 320 }));
+
+    const output = shallow(
+      <ContentPadding>
+        <Text>Something</Text>
+      </ContentPadding>
+    );
+
+    expect(output.props().style[0].paddingHorizontal).toBe(8);
+
+    dimensionsMock.mockRestore();
+  });
+
+  it("adds large padding for large devices", () => {
+    const dimensionsMock = jest
+      .spyOn(Dimensions, "get")
+      .mockImplementation(() => ({ width: 360 }));
+
+    const output = shallow(
+      <ContentPadding>
+        <Text>Something</Text>
+      </ContentPadding>
+    );
+
+    expect(output.props().style[0].paddingHorizontal).toBe(16);
+
+    dimensionsMock.mockRestore();
+  });
+});

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -6,6 +6,7 @@ import formatDate from "date-fns/format";
 
 import EventCard from "./EventCard";
 import Text from "./Text";
+import ContentPadding from "./ContentPadding";
 import type { Event, EventDays, Asset } from "../data/event";
 import {
   bgColor,
@@ -30,37 +31,40 @@ type ItemProps = { item: Event };
 const renderItem = (styles, locale, onPress, getAssetById) => ({
   item: event
 }: ItemProps) => (
-  <TouchableOpacity
-    style={styles.eventListItem}
-    accessibilityTraits={["button"]}
-    accessibilityComponentType="button"
-    delayPressIn={50}
-    onPress={() => onPress(event.sys.id)}
-  >
-    <EventCard
-      name={event.fields.name[locale]}
-      locationName={event.fields.locationName[locale]}
-      eventPriceLow={event.fields.eventPriceLow[locale]}
-      eventPriceHigh={event.fields.eventPriceHigh[locale]}
-      startTime={event.fields.startTime[locale]}
-      endTime={event.fields.endTime[locale]}
-      imageUrl={`https:${
-        getAssetById(event.fields.eventsListPicture[locale].sys.id).fields.file[
-          locale
-        ].url
-      }`}
-      isFree={event.fields.isFree[locale]}
-    />
-  </TouchableOpacity>
+  <ContentPadding>
+    <TouchableOpacity
+      style={styles.eventListItem}
+      accessibilityTraits={["button"]}
+      accessibilityComponentType="button"
+      delayPressIn={50}
+      onPress={() => onPress(event.sys.id)}
+    >
+      <EventCard
+        name={event.fields.name[locale]}
+        locationName={event.fields.locationName[locale]}
+        eventPriceLow={event.fields.eventPriceLow[locale]}
+        eventPriceHigh={event.fields.eventPriceHigh[locale]}
+        startTime={event.fields.startTime[locale]}
+        endTime={event.fields.endTime[locale]}
+        imageUrl={`https:${
+          getAssetById(event.fields.eventsListPicture[locale].sys.id).fields
+            .file[locale].url
+        }`}
+        isFree={event.fields.isFree[locale]}
+      />
+    </TouchableOpacity>
+  </ContentPadding>
 );
 
 type Section = SectionBase<Event> & { title: string };
 
 type SectionProps = { section: Section };
 const renderSectionHeader = styles => ({ section }: SectionProps) => (
-  <Text type="h2" style={styles.sectionHeader}>
-    {section.title}
-  </Text>
+  <ContentPadding style={styles.sectionHeader}>
+    <Text type="h2" style={styles.sectionHeaderText}>
+      {section.title}
+    </Text>
+  </ContentPadding>
 );
 
 const eventSections = (events: EventDays, locale: string): Section[] =>
@@ -104,7 +108,6 @@ const styles = StyleSheet.create({
     backgroundColor: bgColor
   },
   eventListItem: {
-    marginHorizontal: 16,
     borderRadius: 5,
     // The below properties are required for ioS shadow
     shadowColor: eventCardShadow,
@@ -118,9 +121,7 @@ const styles = StyleSheet.create({
   },
   sectionHeader: {
     height: 40,
-    color: eventCardTextColor,
-    paddingVertical: 8,
-    paddingHorizontal: 15,
+    justifyContent: "center",
     backgroundColor: sectionHeaderBgColor,
 
     // The below properties are required for ioS shadow
@@ -132,6 +133,9 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     elevation: 3,
     marginBottom: 6
+  },
+  sectionHeaderText: {
+    color: eventCardTextColor
   },
   sectionFooter: {
     height: 6

--- a/src/components/FilterHeader.js
+++ b/src/components/FilterHeader.js
@@ -6,6 +6,7 @@ import DateFilterDialog from "./ConnectedDateFilterDialog";
 import FilterHeaderButton from "./FilterHeaderButton";
 import TimeFilterDialog from "./ConnectedTimeFilterDialog";
 import Text from "./Text";
+import ContentPadding from "./ContentPadding";
 import {
   interestButtonBgColor,
   interestButtonTextColor,
@@ -61,35 +62,37 @@ class FilterHeader extends React.PureComponent<Props, State> {
     return (
       <SafeAreaView style={styles.container} forceInset={{ top: "always" }}>
         <StatusBar barStyle="light-content" animated />
-        <View testID="filter-header" style={styles.content}>
-          <View style={styles.contentInterest}>
-            <View style={styles.interestButton}>
-              <Text type="h2" style={styles.interestButtonText}>
-                {text.filterByInterest}
-              </Text>
+        <ContentPadding>
+          <View testID="filter-header" style={styles.content}>
+            <View style={styles.contentInterest}>
+              <View style={styles.interestButton}>
+                <Text type="h2" style={styles.interestButtonText}>
+                  {text.filterByInterest}
+                </Text>
+              </View>
+              <View style={styles.mapButton}>
+                <Text style={styles.mapButtonText}>Map</Text>
+              </View>
             </View>
-            <View style={styles.mapButton}>
-              <Text style={styles.mapButtonText}>Map</Text>
+            <View style={styles.contentFilters}>
+              <FilterHeaderButton
+                text={formattedDateFilter}
+                onPress={this.showDatePicker}
+                style={styles.filterButton}
+              />
+              <FilterHeaderButton
+                text={formattedTimeFilter}
+                onPress={this.showTimePicker}
+                style={styles.filterButton}
+              />
+              <FilterHeaderButton
+                text={text.filters}
+                onPress={() => {}}
+                style={styles.filterButton}
+              />
             </View>
           </View>
-          <View style={styles.contentFilters}>
-            <FilterHeaderButton
-              text={formattedDateFilter}
-              onPress={this.showDatePicker}
-              style={styles.filterButton}
-            />
-            <FilterHeaderButton
-              text={formattedTimeFilter}
-              onPress={this.showTimePicker}
-              style={styles.filterButton}
-            />
-            <FilterHeaderButton
-              text={text.filters}
-              onPress={() => {}}
-              style={styles.filterButton}
-            />
-          </View>
-        </View>
+        </ContentPadding>
         <DateFilterDialog
           onApply={this.hideDatePicker}
           onCancel={this.hideDatePicker}
@@ -121,7 +124,6 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 44,
     backgroundColor: interestButtonBgColor,
-    marginLeft: 8,
     paddingHorizontal: 12,
     borderRadius: 4,
     justifyContent: "center"
@@ -130,7 +132,7 @@ const styles = StyleSheet.create({
     color: interestButtonTextColor
   },
   mapButton: {
-    marginHorizontal: 12,
+    marginLeft: 12,
     width: 52,
     height: 52,
     backgroundColor: interestButtonBgColor,
@@ -149,7 +151,7 @@ const styles = StyleSheet.create({
     marginTop: 8
   },
   filterButton: {
-    marginLeft: 8
+    marginRight: 8
   }
 });
 

--- a/src/components/__snapshots__/ContentPadding.test.js.snap
+++ b/src/components/__snapshots__/ContentPadding.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContentPadding renders correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "paddingHorizontal": 16,
+      },
+      Object {},
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    Something
+  </Text>
+</View>
+`;

--- a/src/components/__snapshots__/FilterHeader.test.js.snap
+++ b/src/components/__snapshots__/FilterHeader.test.js.snap
@@ -18,114 +18,117 @@ exports[`renders correctly with any date and any time (empty time set) 1`] = `
     barStyle="light-content"
     showHideTransition="fade"
   />
-  <View
-    style={
-      Object {
-        "paddingBottom": 12,
-        "paddingTop": 16,
-      }
-    }
-    testID="filter-header"
+  <ContentPadding
+    style={Object {}}
   >
     <View
       style={
         Object {
-          "alignItems": "center",
-          "flexDirection": "row",
+          "paddingBottom": 12,
+          "paddingTop": 16,
         }
       }
+      testID="filter-header"
     >
-      <View
-        style={
-          Object {
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 4,
-            "flex": 1,
-            "height": 44,
-            "justifyContent": "center",
-            "marginLeft": 8,
-            "paddingHorizontal": 12,
-          }
-        }
-      >
-        <Text
-          markdown={false}
-          style={
-            Object {
-              "color": "rgb(44, 218, 157)",
-            }
-          }
-          type="h2"
-        >
-          I'm interested in...
-        </Text>
-      </View>
       <View
         style={
           Object {
             "alignItems": "center",
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 25,
-            "height": 52,
-            "justifyContent": "flex-end",
-            "marginHorizontal": 12,
-            "width": 52,
+            "flexDirection": "row",
           }
         }
       >
-        <Text
-          markdown={false}
+        <View
           style={
             Object {
-              "color": "rgb(44, 218, 157)",
-              "fontFamily": "Poppins-Bold",
-              "fontSize": 14,
-              "paddingBottom": 6,
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 4,
+              "flex": 1,
+              "height": 44,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
             }
           }
-          type="text"
         >
-          Map
-        </Text>
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+              }
+            }
+            type="h2"
+          >
+            I'm interested in...
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 25,
+              "height": 52,
+              "justifyContent": "flex-end",
+              "marginLeft": 12,
+              "width": 52,
+            }
+          }
+        >
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+                "fontFamily": "Poppins-Bold",
+                "fontSize": 14,
+                "paddingBottom": 6,
+              }
+            }
+            type="text"
+          >
+            Map
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginTop": 8,
+          }
+        }
+      >
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Any day"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Any time"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Filters"
+        />
       </View>
     </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "marginTop": 8,
-        }
-      }
-    >
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Any day"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Any time"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Filters"
-      />
-    </View>
-  </View>
+  </ContentPadding>
   <Connect(DateRangePickerDialog)
     onApply={[Function]}
     onCancel={[Function]}
@@ -157,114 +160,117 @@ exports[`renders correctly with any date and any time 1`] = `
     barStyle="light-content"
     showHideTransition="fade"
   />
-  <View
-    style={
-      Object {
-        "paddingBottom": 12,
-        "paddingTop": 16,
-      }
-    }
-    testID="filter-header"
+  <ContentPadding
+    style={Object {}}
   >
     <View
       style={
         Object {
-          "alignItems": "center",
-          "flexDirection": "row",
+          "paddingBottom": 12,
+          "paddingTop": 16,
         }
       }
+      testID="filter-header"
     >
-      <View
-        style={
-          Object {
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 4,
-            "flex": 1,
-            "height": 44,
-            "justifyContent": "center",
-            "marginLeft": 8,
-            "paddingHorizontal": 12,
-          }
-        }
-      >
-        <Text
-          markdown={false}
-          style={
-            Object {
-              "color": "rgb(44, 218, 157)",
-            }
-          }
-          type="h2"
-        >
-          I'm interested in...
-        </Text>
-      </View>
       <View
         style={
           Object {
             "alignItems": "center",
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 25,
-            "height": 52,
-            "justifyContent": "flex-end",
-            "marginHorizontal": 12,
-            "width": 52,
+            "flexDirection": "row",
           }
         }
       >
-        <Text
-          markdown={false}
+        <View
           style={
             Object {
-              "color": "rgb(44, 218, 157)",
-              "fontFamily": "Poppins-Bold",
-              "fontSize": 14,
-              "paddingBottom": 6,
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 4,
+              "flex": 1,
+              "height": 44,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
             }
           }
-          type="text"
         >
-          Map
-        </Text>
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+              }
+            }
+            type="h2"
+          >
+            I'm interested in...
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 25,
+              "height": 52,
+              "justifyContent": "flex-end",
+              "marginLeft": 12,
+              "width": 52,
+            }
+          }
+        >
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+                "fontFamily": "Poppins-Bold",
+                "fontSize": 14,
+                "paddingBottom": 6,
+              }
+            }
+            type="text"
+          >
+            Map
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginTop": 8,
+          }
+        }
+      >
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Any day"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Any time"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Filters"
+        />
       </View>
     </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "marginTop": 8,
-        }
-      }
-    >
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Any day"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Any time"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Filters"
-      />
-    </View>
-  </View>
+  </ContentPadding>
   <Connect(DateRangePickerDialog)
     onApply={[Function]}
     onCancel={[Function]}
@@ -296,114 +302,117 @@ exports[`renders correctly with date range and two times 1`] = `
     barStyle="light-content"
     showHideTransition="fade"
   />
-  <View
-    style={
-      Object {
-        "paddingBottom": 12,
-        "paddingTop": 16,
-      }
-    }
-    testID="filter-header"
+  <ContentPadding
+    style={Object {}}
   >
     <View
       style={
         Object {
-          "alignItems": "center",
-          "flexDirection": "row",
+          "paddingBottom": 12,
+          "paddingTop": 16,
         }
       }
+      testID="filter-header"
     >
-      <View
-        style={
-          Object {
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 4,
-            "flex": 1,
-            "height": 44,
-            "justifyContent": "center",
-            "marginLeft": 8,
-            "paddingHorizontal": 12,
-          }
-        }
-      >
-        <Text
-          markdown={false}
-          style={
-            Object {
-              "color": "rgb(44, 218, 157)",
-            }
-          }
-          type="h2"
-        >
-          I'm interested in...
-        </Text>
-      </View>
       <View
         style={
           Object {
             "alignItems": "center",
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 25,
-            "height": 52,
-            "justifyContent": "flex-end",
-            "marginHorizontal": 12,
-            "width": 52,
+            "flexDirection": "row",
           }
         }
       >
-        <Text
-          markdown={false}
+        <View
           style={
             Object {
-              "color": "rgb(44, 218, 157)",
-              "fontFamily": "Poppins-Bold",
-              "fontSize": 14,
-              "paddingBottom": 6,
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 4,
+              "flex": 1,
+              "height": 44,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
             }
           }
-          type="text"
         >
-          Map
-        </Text>
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+              }
+            }
+            type="h2"
+          >
+            I'm interested in...
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 25,
+              "height": 52,
+              "justifyContent": "flex-end",
+              "marginLeft": 12,
+              "width": 52,
+            }
+          }
+        >
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+                "fontFamily": "Poppins-Bold",
+                "fontSize": 14,
+                "paddingBottom": 6,
+              }
+            }
+            type="text"
+          >
+            Map
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginTop": 8,
+          }
+        }
+      >
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="2 Feb - 3 Feb"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Morning, Afternoon"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Filters"
+        />
       </View>
     </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "marginTop": 8,
-        }
-      }
-    >
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="2 Feb - 3 Feb"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Morning, Afternoon"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Filters"
-      />
-    </View>
-  </View>
+  </ContentPadding>
   <Connect(DateRangePickerDialog)
     onApply={[Function]}
     onCancel={[Function]}
@@ -435,114 +444,117 @@ exports[`renders correctly with single date and single time 1`] = `
     barStyle="light-content"
     showHideTransition="fade"
   />
-  <View
-    style={
-      Object {
-        "paddingBottom": 12,
-        "paddingTop": 16,
-      }
-    }
-    testID="filter-header"
+  <ContentPadding
+    style={Object {}}
   >
     <View
       style={
         Object {
-          "alignItems": "center",
-          "flexDirection": "row",
+          "paddingBottom": 12,
+          "paddingTop": 16,
         }
       }
+      testID="filter-header"
     >
-      <View
-        style={
-          Object {
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 4,
-            "flex": 1,
-            "height": 44,
-            "justifyContent": "center",
-            "marginLeft": 8,
-            "paddingHorizontal": 12,
-          }
-        }
-      >
-        <Text
-          markdown={false}
-          style={
-            Object {
-              "color": "rgb(44, 218, 157)",
-            }
-          }
-          type="h2"
-        >
-          I'm interested in...
-        </Text>
-      </View>
       <View
         style={
           Object {
             "alignItems": "center",
-            "backgroundColor": "rgb(32, 33, 90)",
-            "borderRadius": 25,
-            "height": 52,
-            "justifyContent": "flex-end",
-            "marginHorizontal": 12,
-            "width": 52,
+            "flexDirection": "row",
           }
         }
       >
-        <Text
-          markdown={false}
+        <View
           style={
             Object {
-              "color": "rgb(44, 218, 157)",
-              "fontFamily": "Poppins-Bold",
-              "fontSize": 14,
-              "paddingBottom": 6,
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 4,
+              "flex": 1,
+              "height": 44,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
             }
           }
-          type="text"
         >
-          Map
-        </Text>
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+              }
+            }
+            type="h2"
+          >
+            I'm interested in...
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgb(32, 33, 90)",
+              "borderRadius": 25,
+              "height": 52,
+              "justifyContent": "flex-end",
+              "marginLeft": 12,
+              "width": 52,
+            }
+          }
+        >
+          <Text
+            markdown={false}
+            style={
+              Object {
+                "color": "rgb(44, 218, 157)",
+                "fontFamily": "Poppins-Bold",
+                "fontSize": 14,
+                "paddingBottom": 6,
+              }
+            }
+            type="text"
+          >
+            Map
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginTop": 8,
+          }
+        }
+      >
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="2 Feb"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Afternoon"
+        />
+        <FilterHeaderButton
+          onPress={[Function]}
+          style={
+            Object {
+              "marginRight": 8,
+            }
+          }
+          text="Filters"
+        />
       </View>
     </View>
-    <View
-      style={
-        Object {
-          "flexDirection": "row",
-          "marginTop": 8,
-        }
-      }
-    >
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="2 Feb"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Afternoon"
-      />
-      <FilterHeaderButton
-        onPress={[Function]}
-        style={
-          Object {
-            "marginLeft": 8,
-          }
-        }
-        text="Filters"
-      />
-    </View>
-  </View>
+  </ContentPadding>
   <Connect(DateRangePickerDialog)
     onApply={[Function]}
     onCancel={[Function]}

--- a/src/screens/EventDetailsScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/EventDetailsScreen/__snapshots__/component.test.js.snap
@@ -13,12 +13,12 @@ exports[`renders correctly 1`] = `
     imageUrl="https://images.ctfassets.net/n2o4hgsv6wcx/HNLFqItbkAmW8ssqQECIy/b1262a7a1180e87d14f852f265d9c36c/event-pride-in-the-park_1.jpg"
     onBackButtonPress={[Function]}
   />
-  <View
+  <ContentPadding
     style={
       Object {
         "backgroundColor": "#FFF",
         "flex": 1,
-        "padding": 15,
+        "paddingVertical": 15,
       }
     }
   >
@@ -182,7 +182,7 @@ exports[`renders correctly 1`] = `
         titleType="h3"
       />
     </View>
-  </View>
+  </ContentPadding>
   <View
     style={
       Object {
@@ -191,12 +191,12 @@ exports[`renders correctly 1`] = `
       }
     }
   />
-  <View
+  <ContentPadding
     style={
       Object {
         "backgroundColor": "#FFF",
         "flex": 1,
-        "padding": 15,
+        "paddingVertical": 15,
       }
     }
   >
@@ -222,8 +222,10 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
         lon={-0.12092150000000856}
       />
     </View>
-  </View>
-  <View>
+  </ContentPadding>
+  <ContentPadding
+    style={Object {}}
+  >
     <View
       style={
         Object {
@@ -237,7 +239,7 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
         Object {
           "backgroundColor": "#FFF",
           "flex": 1,
-          "padding": 15,
+          "paddingVertical": 15,
         }
       }
     >
@@ -343,6 +345,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
         />
       </View>
     </View>
-  </View>
+  </ContentPadding>
 </ScrollView>
 `;

--- a/src/screens/EventDetailsScreen/component.js
+++ b/src/screens/EventDetailsScreen/component.js
@@ -10,6 +10,7 @@ import CategoryLabel from "./CategoryLabel";
 import EventMap from "./EventMap";
 import Text from "../../components/Text";
 import Button from "../../components/Button";
+import ContentPadding from "../../components/ContentPadding";
 import {
   eventDetailsBgColor,
   eventDetailsHeaderBgColor
@@ -47,7 +48,7 @@ const renderEventOverview = event => {
   )}`;
 
   return (
-    <View style={styles.content}>
+    <ContentPadding style={styles.content}>
       <Text type="h1">{event.fields.name[locale]}</Text>
       <View style={styles.categoryLabelContainer}>
         {event.fields.eventCategories[locale].map(categoryName => (
@@ -100,12 +101,12 @@ const renderEventOverview = event => {
             />
           </View>
         )}
-    </View>
+    </ContentPadding>
   );
 };
 
 const renderEventDescription = event => (
-  <View style={styles.content}>
+  <ContentPadding style={styles.content}>
     <Text markdown>{event.fields.eventDescription[locale]}</Text>
     <View style={styles.mapWrapper}>
       <EventMap
@@ -114,7 +115,7 @@ const renderEventDescription = event => (
         locationName={event.fields.locationName[locale]}
       />
     </View>
-  </View>
+  </ContentPadding>
 );
 
 const renderEventDetails = event =>
@@ -122,7 +123,7 @@ const renderEventDetails = event =>
     event.fields.email ||
     event.fields.phone ||
     event.fields.ticketingUrl) && (
-    <View>
+    <ContentPadding>
       <View style={styles.sectionDivider} />
       <View style={styles.content}>
         {event.fields.accessibilityDetails && (
@@ -165,7 +166,7 @@ const renderEventDetails = event =>
           </View>
         )}
       </View>
-    </View>
+    </ContentPadding>
   );
 
 class EventDetailsScreen extends PureComponent<Props> {
@@ -203,7 +204,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    padding: 15,
+    paddingVertical: 15,
     backgroundColor: eventDetailsBgColor
   },
   categoryLabelContainer: {


### PR DESCRIPTION
The designs define that our horizontal margins on the edge of the screen should be 8px for small phones and 16px for larger phones:

Small: https://app.zeplin.io/project/5a916701f75c524181eebe68/screen/5a98852abdd77cfa80d8a17d
Large: https://app.zeplin.io/project/5a916701f75c524181eebe68/screen/5a98853c327dbb30566c00a1

We should be handling this, so here's a component to do it.

<img width="944" alt="screen shot 2018-03-25 at 21 17 32" src="https://user-images.githubusercontent.com/2011550/37879502-f84fa4aa-3071-11e8-8cce-7f7fed925628.png">

## Pre-flight check-list

Before raising a pull request

* ~~Documentation~~
* [x] Unit tests

## Pre-merge check-list

* ~~Tester approved~~
