### PR TITLE
Small improvements of date filter UX

### DIFF
--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -27,8 +27,10 @@ const getSortedDateRange = (dates: DateRange) => {
 
 const getMarkedDate = (date: string) => ({
   [date]: {
-    selected: true,
-    selectedColor: eventListHeaderColor
+    startingDay: true,
+    endingDay: true,
+    color: eventListHeaderColor,
+    textColor: cardBgColor
   }
 });
 
@@ -63,17 +65,17 @@ const getMarkedDateRange = (dateRange: DateRange) => {
   return markedDates;
 };
 
-const getCalendarMarkingProps = (dateRange: ?DateOrDateRange) => {
-  if (dateRange && typeof dateRange === "string") {
-    return {
-      markingType: "simple",
-      markedDates: getMarkedDate(dateRange)
-    };
-  } else if (dateRange && typeof dateRange === "object") {
-    return {
-      markingType: "period",
-      markedDates: getMarkedDateRange(dateRange)
-    };
+const getMarkedDates = (dateRange: ?DateOrDateRange) => {
+  if (!dateRange) {
+    return {};
+  }
+
+  if (typeof dateRange === "string") {
+    return getMarkedDate(dateRange);
+  }
+
+  if (typeof dateRange === "object") {
+    return getMarkedDateRange(dateRange);
   }
 
   return {};
@@ -87,21 +89,14 @@ type Props = {
 class DateRangePicker extends React.PureComponent<Props> {
   onDaySelected = (day: CalendarDay) => {
     const { dateRange, onChange } = this.props;
-    if (!dateRange) {
-      onChange(day.dateString);
-    } else if (typeof dateRange === "string") {
+
+    if (!dateRange || typeof dateRange !== "string") {
+      return onChange(day.dateString);
+    }
+
+    if (typeof dateRange === "string") {
       onChange(
-        getSortedDateRange({
-          startDate: dateRange,
-          endDate: day.dateString
-        })
-      );
-    } else {
-      onChange(
-        getSortedDateRange({
-          ...dateRange,
-          endDate: day.dateString
-        })
+        getSortedDateRange({ startDate: dateRange, endDate: day.dateString })
       );
     }
   };
@@ -112,12 +107,10 @@ class DateRangePicker extends React.PureComponent<Props> {
         ? getSortedDateRange(this.props.dateRange)
         : this.props.dateRange;
 
-    const { markingType, markedDates } = getCalendarMarkingProps(dateRange);
-
     return (
       <Calendar
-        markedDates={markedDates}
-        markingType={markingType}
+        markedDates={getMarkedDates(dateRange)}
+        markingType="period"
         onDayPress={this.onDaySelected}
         theme={{
           textDayFontFamily: "Roboto",

--- a/src/components/DateRangePicker.js
+++ b/src/components/DateRangePicker.js
@@ -74,11 +74,7 @@ const getMarkedDates = (dateRange: ?DateOrDateRange) => {
     return getMarkedDate(dateRange);
   }
 
-  if (typeof dateRange === "object") {
-    return getMarkedDateRange(dateRange);
-  }
-
-  return {};
+  return getMarkedDateRange(dateRange);
 };
 
 type Props = {
@@ -94,11 +90,9 @@ class DateRangePicker extends React.PureComponent<Props> {
       return onChange(day.dateString);
     }
 
-    if (typeof dateRange === "string") {
-      onChange(
-        getSortedDateRange({ startDate: dateRange, endDate: day.dateString })
-      );
-    }
+    onChange(
+      getSortedDateRange({ startDate: dateRange, endDate: day.dateString })
+    );
   };
 
   render() {

--- a/src/components/DateRangePicker.test.js
+++ b/src/components/DateRangePicker.test.js
@@ -97,22 +97,6 @@ describe("onChange", () => {
       endDate: "2018-11-25"
     });
     onDayPress(getCalendarDay("2018-11-28"));
-    expect(onChange).toHaveBeenCalledWith({
-      startDate: "2018-11-22",
-      endDate: "2018-11-28"
-    });
-  });
-
-  it("reports sorted date range when second day is changed", () => {
-    const onChange = jest.fn();
-    const onDayPress = render(onChange, {
-      startDate: "2018-11-22",
-      endDate: "2018-11-25"
-    });
-    onDayPress(getCalendarDay("2018-11-10"));
-    expect(onChange).toHaveBeenCalledWith({
-      startDate: "2018-11-10",
-      endDate: "2018-11-22"
-    });
+    expect(onChange).toHaveBeenCalledWith("2018-11-28");
   });
 });

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,7 +1,13 @@
 // @flow
 import React from "react";
 import type { Node } from "react";
-import { Modal, StyleSheet, TouchableOpacity, View } from "react-native";
+import {
+  Modal,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View
+} from "react-native";
 import Text from "./Text";
 import {
   dialogBackdropColor,
@@ -39,30 +45,34 @@ const Dialog = ({
     transparent
     visible={visible}
   >
-    <View style={styles.container}>
-      <View style={styles.content}>
-        <View style={styles.header}>
-          <View style={[styles.headerSide, styles.headerSideLeft]}>
-            {headerLeft}
+    <TouchableWithoutFeedback style={styles.backdrop} onPress={onCancel}>
+      <View style={styles.container}>
+        <TouchableWithoutFeedback>
+          <View style={styles.content}>
+            <View style={styles.header}>
+              <View style={[styles.headerSide, styles.headerSideLeft]}>
+                {headerLeft}
+              </View>
+              <Text type="h3" style={styles.headerTitle}>
+                {title}
+              </Text>
+              <View style={[styles.headerSide, styles.headerSideRight]}>
+                {headerRight}
+              </View>
+            </View>
+            {children}
           </View>
-          <Text type="h3" style={styles.headerTitle}>
-            {title}
-          </Text>
-          <View style={[styles.headerSide, styles.headerSideRight]}>
-            {headerRight}
-          </View>
-        </View>
-        {children}
+        </TouchableWithoutFeedback>
+        <TouchableOpacity
+          accessibilityTraits={["button"]}
+          accessibilityComponentType="button"
+          onPress={onApply}
+          style={styles.applyButton}
+        >
+          <Text style={styles.applyButtonText}>{applyButtonText}</Text>
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        accessibilityTraits={["button"]}
-        accessibilityComponentType="button"
-        onPress={onApply}
-        style={styles.applyButton}
-      >
-        <Text style={styles.applyButtonText}>{applyButtonText}</Text>
-      </TouchableOpacity>
-    </View>
+    </TouchableWithoutFeedback>
   </Modal>
 );
 
@@ -73,6 +83,9 @@ Dialog.defaultProps = {
 };
 
 const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject
+  },
   container: {
     ...StyleSheet.absoluteFillObject,
     justifyContent: "center",

--- a/src/components/__snapshots__/DateRangePicker.test.js.snap
+++ b/src/components/__snapshots__/DateRangePicker.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`renders correctly no dates 1`] = `
 <Calendar
+  markedDates={Object {}}
+  markingType="period"
   onDayPress={[Function]}
   theme={
     Object {
@@ -21,12 +23,14 @@ exports[`renders correctly only startDate 1`] = `
   markedDates={
     Object {
       "2018-01-01": Object {
-        "selected": true,
-        "selectedColor": "rgb(51, 51, 51)",
+        "color": "rgb(51, 51, 51)",
+        "endingDay": true,
+        "startingDay": true,
+        "textColor": "rgb(255, 255, 255)",
       },
     }
   }
-  markingType="simple"
+  markingType="period"
   onDayPress={[Function]}
   theme={
     Object {
@@ -108,12 +112,14 @@ exports[`renders correctly startDate equals endDate 1`] = `
   markedDates={
     Object {
       "2018-01-01": Object {
-        "selected": true,
-        "selectedColor": "rgb(51, 51, 51)",
+        "color": "rgb(51, 51, 51)",
+        "endingDay": true,
+        "startingDay": true,
+        "textColor": "rgb(255, 255, 255)",
       },
     }
   }
-  markingType="simple"
+  markingType="period"
   onDayPress={[Function]}
   theme={
     Object {

--- a/src/components/__snapshots__/Dialog.test.js.snap
+++ b/src/components/__snapshots__/Dialog.test.js.snap
@@ -8,14 +8,12 @@ exports[`renders correctly 1`] = `
   transparent={true}
   visible={true}
 >
-  <View
+  <TouchableWithoutFeedback
+    onPress={[Function]}
     style={
       Object {
-        "backgroundColor": "rgba(0, 0, 0, 0.7)",
         "bottom": 0,
-        "justifyContent": "center",
         "left": 0,
-        "padding": 16,
         "position": "absolute",
         "right": 0,
         "top": 0,
@@ -25,97 +23,114 @@ exports[`renders correctly 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#FFFFFF",
-          "borderRadius": 4,
-          "paddingBottom": 8,
+          "backgroundColor": "rgba(0, 0, 0, 0.7)",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "padding": 16,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
         }
       }
     >
-      <View
+      <TouchableWithoutFeedback>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#FFFFFF",
+              "borderRadius": 4,
+              "paddingBottom": 8,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderBottomColor": "#F2F2F2",
+                "borderBottomWidth": 1,
+                "flexDirection": "row",
+                "height": 40,
+                "justifyContent": "space-between",
+                "paddingHorizontal": 16,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "width": 0,
+                  },
+                  Object {
+                    "alignItems": "flex-start",
+                  },
+                ]
+              }
+            />
+            <Text
+              markdown={false}
+              style={
+                Object {
+                  "color": "#272727",
+                }
+              }
+              type="h3"
+            >
+              Hello World
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "width": 0,
+                  },
+                  Object {
+                    "alignItems": "flex-end",
+                  },
+                ]
+              }
+            />
+          </View>
+          Lorem Ipsum is placeholder text commonly used...
+        </View>
+      </TouchableWithoutFeedback>
+      <TouchableOpacity
+        accessibilityComponentType="button"
+        accessibilityTraits={
+          Array [
+            "button",
+          ]
+        }
+        activeOpacity={0.2}
+        onPress={[Function]}
         style={
           Object {
             "alignItems": "center",
-            "borderBottomColor": "#F2F2F2",
-            "borderBottomWidth": 1,
-            "flexDirection": "row",
-            "height": 40,
-            "justifyContent": "space-between",
-            "paddingHorizontal": 16,
+            "backgroundColor": "rgb(51, 51, 51)",
+            "borderRadius": 4,
+            "height": 48,
+            "justifyContent": "center",
+            "marginTop": 8,
           }
         }
       >
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "width": 0,
-              },
-              Object {
-                "alignItems": "flex-start",
-              },
-            ]
-          }
-        />
         <Text
           markdown={false}
           style={
             Object {
-              "color": "#272727",
+              "color": "#FFFFFF",
             }
           }
-          type="h3"
+          type="text"
         >
-          Hello World
+          Bye
         </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "width": 0,
-              },
-              Object {
-                "alignItems": "flex-end",
-              },
-            ]
-          }
-        />
-      </View>
-      Lorem Ipsum is placeholder text commonly used...
+      </TouchableOpacity>
     </View>
-    <TouchableOpacity
-      accessibilityComponentType="button"
-      accessibilityTraits={
-        Array [
-          "button",
-        ]
-      }
-      activeOpacity={0.2}
-      onPress={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "rgb(51, 51, 51)",
-          "borderRadius": 4,
-          "height": 48,
-          "justifyContent": "center",
-          "marginTop": 8,
-        }
-      }
-    >
-      <Text
-        markdown={false}
-        style={
-          Object {
-            "color": "#FFFFFF",
-          }
-        }
-        type="text"
-      >
-        Bye
-      </Text>
-    </TouchableOpacity>
-  </View>
+  </TouchableWithoutFeedback>
 </Component>
 `;


### PR DESCRIPTION
This improves the UX of the date picker filter dialog a little bit to be more intuitive. The main change is after selecting a date range, the next tap now starts a new date range. Also, tapping the grey backdrop will dismiss the dialog.

[add video]

The rest of this are little bugfixes.

## To do

- [x] make backdrop touchable to dismiss dialogs
- [x] more intuitive date range selection
- [x] fix visual bug caused by switching selection styles
- [ ] open date filter showing start of the date range
- [ ] when date filter is open with a single day selected, next tap should select a new single day (this will be tricky)

## Pre-flight check-list

Before raising a pull request

* [x] Unit tests
