### PR TITLE
Perform internal deploy before TestFlight

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -59,19 +59,6 @@ platform :ios do
   desc "Beta build and deploy"
   lane :beta do |options|
     ensure_git_branch(branch: "master")
-    increment_build_number(
-      build_number: latest_testflight_build_number + 1,
-      xcodeproj: "PrideLondonApp.xcodeproj"
-    )
-    build(
-      match_type: "appstore",
-      export_method: "app-store",
-      configuration: "Release",
-      app_identifier: "org.prideinlondon.festival"
-    )
-    if options[:submit]
-      deploy_testflight 
-    end
     increment_build_number(build_number:options[:ci_build_num])
     build(
       match_type: "adhoc", 
@@ -96,6 +83,21 @@ platform :ios do
         notify: "1",
         notes: notes,
       )
+    end
+    # Testflight builds can be promoted to production so 
+    # we have to do another build with appstore signing
+    increment_build_number(
+      build_number: latest_testflight_build_number + 1,
+      xcodeproj: "PrideLondonApp.xcodeproj"
+    )
+    build(
+      match_type: "appstore",
+      export_method: "app-store",
+      configuration: "Release",
+      app_identifier: "org.prideinlondon.festival"
+    )
+    if options[:submit]
+      deploy_testflight 
     end
   end
 


### PR DESCRIPTION
Because TestFlight builds take a while to be available we might as well deploy to hockey/beta first so that they're available to us sooner.
