### PR TITLE
Standardize touchable components (e.g. buttons)

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
-import { StyleSheet, TouchableOpacity, Linking } from "react-native";
+import { StyleSheet, Linking } from "react-native";
+import Touchable from "./Touchable";
 import Text from "./Text";
 import {
   eventDetailsBuyButtonColor,
@@ -19,9 +20,9 @@ const onPress = url => {
 };
 
 const Button = ({ text, url }: Props) => (
-  <TouchableOpacity style={styles.button} onPress={() => onPress(url)}>
+  <Touchable style={styles.button} onPress={() => onPress(url)}>
     <Text style={styles.text}>{text}</Text>
-  </TouchableOpacity>
+  </Touchable>
 );
 Button.defaultProps = {
   url: ""
@@ -29,7 +30,6 @@ Button.defaultProps = {
 
 const styles = StyleSheet.create({
   button: {
-    height: 40,
     backgroundColor: eventDetailsBuyButtonColor,
     borderRadius: 4,
     alignItems: "center",

--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -1,8 +1,9 @@
 // @flow
 import React from "react";
-import { Image, StyleSheet, TouchableOpacity } from "react-native";
+import { Image, StyleSheet } from "react-native";
 import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 import Text from "./Text";
+import Touchable from "./Touchable";
 
 import checkBoxCheckedUrl from "./check-box-checked.png";
 
@@ -14,7 +15,7 @@ type Props = {
 };
 
 const CheckBox = ({ checked, label, onChange, style }: Props) => (
-  <TouchableOpacity
+  <Touchable
     accessibilityComponentType={
       checked ? "radiobutton_checked" : "radiobutton_unchecked"
     }
@@ -24,7 +25,7 @@ const CheckBox = ({ checked, label, onChange, style }: Props) => (
   >
     <Text>{label}</Text>
     {checked && <Image source={checkBoxCheckedUrl} />}
-  </TouchableOpacity>
+  </Touchable>
 );
 
 CheckBox.defaultProps = {

--- a/src/components/DateRangePickerDialog.js
+++ b/src/components/DateRangePickerDialog.js
@@ -1,9 +1,9 @@
 // @flow
 import React from "react";
-import { TouchableOpacity } from "react-native";
 import DateRangePicker from "./DateRangePicker";
 import Dialog from "./Dialog";
 import Text from "./Text";
+import Touchable from "./Touchable";
 import text from "../constants/text";
 import type { DateOrDateRange } from "../data/date-time";
 import { formatDateRange } from "../data/formatters";
@@ -32,13 +32,9 @@ class DateRangePickerDialog extends React.PureComponent<Props> {
       <Dialog
         applyButtonText={this.props.applyButtonText}
         headerRight={
-          <TouchableOpacity
-            accessibilityTraits={["button"]}
-            accessibilityComponentType="button"
-            onPress={this.clear}
-          >
+          <Touchable onPress={this.clear}>
             <Text>Clear</Text>
-          </TouchableOpacity>
+          </Touchable>
         }
         onApply={this.props.onApply}
         onCancel={this.props.onCancel}

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,8 +1,9 @@
 // @flow
 import React from "react";
 import type { Node } from "react";
-import { Modal, StyleSheet, TouchableOpacity, View } from "react-native";
+import { Modal, StyleSheet, View } from "react-native";
 import Text from "./Text";
+import Touchable from "./Touchable";
 import {
   dialogBackdropColor,
   dialogBgColor,
@@ -54,14 +55,9 @@ const Dialog = ({
         </View>
         {children}
       </View>
-      <TouchableOpacity
-        accessibilityTraits={["button"]}
-        accessibilityComponentType="button"
-        onPress={onApply}
-        style={styles.applyButton}
-      >
+      <Touchable onPress={onApply} style={styles.applyButton}>
         <Text style={styles.applyButtonText}>{applyButtonText}</Text>
-      </TouchableOpacity>
+      </Touchable>
     </View>
   </Modal>
 );

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -3,7 +3,6 @@ import React from "react";
 import { View, StyleSheet, ImageBackground } from "react-native";
 import formatDate from "date-fns/format";
 import {
-  cardBgColor,
   eventPriceBgColor,
   eventCardTextColor,
   eventPriceColor
@@ -82,7 +81,6 @@ const EventCard = ({
 const styles = StyleSheet.create({
   eventCard: {
     height: 108,
-    backgroundColor: cardBgColor,
     flexDirection: "row",
     overflow: "hidden",
     borderRadius: 5

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -1,12 +1,13 @@
 // @flow
 import React from "react";
-import { StyleSheet, SectionList, TouchableOpacity, View } from "react-native";
+import { StyleSheet, SectionList, View } from "react-native";
 import type { SectionBase } from "react-native/Libraries/Lists/SectionList";
 import formatDate from "date-fns/format";
 
 import ContentPadding from "./ContentPadding";
 import EventCard from "./EventCard";
 import Text from "./Text";
+import Touchable from "./Touchable";
 import type { Event, EventDays, LocalizedFieldRef } from "../data/event";
 import {
   bgColor,
@@ -32,11 +33,8 @@ const renderItem = (styles, locale, onPress, getAssetUrl) => ({
   item: event
 }: ItemProps) => (
   <ContentPadding>
-    <TouchableOpacity
+    <Touchable
       style={styles.eventListItem}
-      accessibilityTraits={["button"]}
-      accessibilityComponentType="button"
-      delayPressIn={50}
       onPress={() => onPress(event.sys.id)}
     >
       <EventCard
@@ -49,7 +47,7 @@ const renderItem = (styles, locale, onPress, getAssetUrl) => ({
         imageUrl={getAssetUrl(event.fields.eventsListPicture)}
         isFree={event.fields.isFree[locale]}
       />
-    </TouchableOpacity>
+    </Touchable>
   </ContentPadding>
 );
 

--- a/src/components/EventTile.js
+++ b/src/components/EventTile.js
@@ -3,11 +3,7 @@ import { format } from "date-fns";
 import React from "react";
 import { View, StyleSheet, ImageBackground } from "react-native";
 import Text from "../components/Text";
-import {
-  imageBgColor,
-  cardBgColor,
-  eventTileTextColor
-} from "../constants/colors";
+import { imageBgColor, eventTileTextColor } from "../constants/colors";
 
 type Props = {
   name: string,
@@ -40,7 +36,6 @@ const EventTile = ({ name, date, imageUrl }: Props) => (
 
 const styles = StyleSheet.create({
   eventTile: {
-    backgroundColor: cardBgColor,
     flexDirection: "column",
     overflow: "hidden"
   },

--- a/src/components/FilterHeaderButton.js
+++ b/src/components/FilterHeaderButton.js
@@ -1,12 +1,10 @@
 // @flow
 import React from "react";
-import { TouchableOpacity, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 import Text from "./Text";
-import {
-  filterButtonBorderColor,
-  filterButtonTextColor
-} from "../constants/colors";
+import Touchable from "./Touchable";
+import { filterButtonTextColor } from "../constants/colors";
 
 type Props = {
   text: string,
@@ -16,17 +14,9 @@ type Props = {
 };
 
 const FilterHeaderButton = ({ text, onPress, onRef, style }: Props) => (
-  <TouchableOpacity
-    accessibilityTraits={["button"]}
-    accessibilityComponentType="button"
-    style={[styles.button, style]}
-    onPress={onPress}
-    ref={onRef}
-  >
-    <Text type="text" style={styles.buttonText}>
-      {text}
-    </Text>
-  </TouchableOpacity>
+  <Touchable style={[styles.button, style]} onPress={onPress} ref={onRef}>
+    <Text style={styles.buttonText}>{text}</Text>
+  </Touchable>
 );
 
 FilterHeaderButton.defaultProps = {
@@ -36,16 +26,13 @@ FilterHeaderButton.defaultProps = {
 
 const styles = StyleSheet.create({
   button: {
-    height: 32,
     paddingHorizontal: 8,
-    borderWidth: 1,
-    borderColor: filterButtonBorderColor,
-    borderRadius: 4,
     alignItems: "center",
     justifyContent: "center"
   },
   buttonText: {
-    color: filterButtonTextColor
+    color: filterButtonTextColor,
+    fontFamily: "Roboto-Medium"
   }
 });
 

--- a/src/components/Touchable.android.js
+++ b/src/components/Touchable.android.js
@@ -9,7 +9,7 @@ const Touchable = ({ children, style, ...props }: TouchableProps) => (
     background={TouchableNativeFeedback.SelectableBackground()}
     {...props}
   >
-    <View style={[styles.default, style]}>{children}</View>
+    <View style={[styles.defaults, style]}>{children}</View>
   </TouchableNativeFeedback>
 );
 
@@ -18,7 +18,7 @@ Touchable.defaultProps = {
 };
 
 const styles = StyleSheet.create({
-  default: {
+  defaults: {
     minHeight: 44,
     minWidth: 44,
     justifyContent: "center"

--- a/src/components/Touchable.android.js
+++ b/src/components/Touchable.android.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+import { StyleSheet, TouchableNativeFeedback, View } from "react-native";
+import type { TouchableProps } from "./TouchableTypes";
+import { TouchableDefaultProps } from "./TouchableTypes";
+
+const Touchable = ({ children, style, ...props }: TouchableProps) => (
+  <TouchableNativeFeedback
+    background={TouchableNativeFeedback.SelectableBackground()}
+    {...props}
+  >
+    <View style={[styles.default, style]}>{children}</View>
+  </TouchableNativeFeedback>
+);
+
+Touchable.defaultProps = {
+  ...TouchableDefaultProps
+};
+
+const styles = StyleSheet.create({
+  default: {
+    minHeight: 44,
+    minWidth: 44,
+    justifyContent: "center"
+  }
+});
+
+export default Touchable;

--- a/src/components/Touchable.android.test.js
+++ b/src/components/Touchable.android.test.js
@@ -1,0 +1,27 @@
+// @flow
+import React from "react";
+import { shallow } from "enzyme";
+import Touchable from "./Touchable.android";
+
+jest.mock("react-native", () => {
+  const TouchableNativeFeedback = () => null;
+  TouchableNativeFeedback.SelectableBackground = jest.fn(
+    () => "mock background"
+  );
+
+  return {
+    StyleSheet: {
+      create: jest.fn(() => ({
+        defaults: { color: "red" }
+      }))
+    },
+    TouchableNativeFeedback,
+    View: () => null
+  };
+});
+
+it("renders correctly", () => {
+  const style = { borderRadius: 2 };
+  const output = shallow(<Touchable style={style}>Hello</Touchable>);
+  expect(output).toMatchSnapshot();
+});

--- a/src/components/Touchable.ios.js
+++ b/src/components/Touchable.ios.js
@@ -5,7 +5,7 @@ import type { TouchableProps } from "./TouchableTypes";
 import { TouchableDefaultProps } from "./TouchableTypes";
 
 const Touchable = ({ children, style, ...props }: TouchableProps) => (
-  <TouchableOpacity style={[styles.default, style]} {...props}>
+  <TouchableOpacity style={[styles.defaults, style]} {...props}>
     {children}
   </TouchableOpacity>
 );
@@ -16,7 +16,7 @@ Touchable.defaultProps = {
 };
 
 const styles = StyleSheet.create({
-  default: {
+  defaults: {
     minHeight: 44,
     minWidth: 44,
     justifyContent: "center"

--- a/src/components/Touchable.ios.js
+++ b/src/components/Touchable.ios.js
@@ -1,0 +1,26 @@
+// @flow
+import React from "react";
+import { StyleSheet, TouchableOpacity } from "react-native";
+import type { TouchableProps } from "./TouchableTypes";
+import { TouchableDefaultProps } from "./TouchableTypes";
+
+const Touchable = ({ children, style, ...props }: TouchableProps) => (
+  <TouchableOpacity style={[styles.default, style]} {...props}>
+    {children}
+  </TouchableOpacity>
+);
+
+Touchable.defaultProps = {
+  ...TouchableDefaultProps,
+  delayPressIn: 50
+};
+
+const styles = StyleSheet.create({
+  default: {
+    minHeight: 44,
+    minWidth: 44,
+    justifyContent: "center"
+  }
+});
+
+export default Touchable;

--- a/src/components/Touchable.ios.test.js
+++ b/src/components/Touchable.ios.test.js
@@ -1,0 +1,15 @@
+// @flow
+import React from "react";
+import { Text } from "react-native";
+import { shallow } from "enzyme";
+import Touchable from "./Touchable.ios";
+
+it("renders correctly", () => {
+  const style = { borderRadius: 2 };
+  const output = shallow(
+    <Touchable style={style}>
+      <Text>Hello</Text>
+    </Touchable>
+  );
+  expect(output).toMatchSnapshot();
+});

--- a/src/components/TouchableTypes.js
+++ b/src/components/TouchableTypes.js
@@ -1,0 +1,44 @@
+// @flow
+import type { Node } from "react";
+import type {
+  AccessibilityComponentType,
+  AccessibilityTrait
+} from "react-native/Libraries/Components/View/ViewAccessibility";
+import type { EdgeInsetsProp } from "react-native/Libraries/StyleSheet/EdgeInsetsPropType";
+import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
+
+export type TouchableProps = {
+  children: Node,
+  style?: StyleObj,
+  accessible?: boolean,
+  accessibilityComponentType?: AccessibilityComponentType,
+  accessibilityTraits?: AccessibilityTrait[],
+  disabled?: boolean,
+  onPress?: Function,
+  onPressIn?: Function,
+  onPressOut?: Function,
+  onLongPress?: Function,
+  delayPressIn?: number,
+  delayPressOut?: number,
+  delayLongPress?: number,
+  pressRetentionOffset?: EdgeInsetsProp,
+  hitSlop?: EdgeInsetsProp
+};
+
+/* eslint-disable import/prefer-default-export */
+export const TouchableDefaultProps = {
+  style: undefined,
+  accessible: undefined,
+  accessibilityComponentType: "button",
+  accessibilityTraits: ["button"],
+  disabled: undefined,
+  onPress: undefined,
+  onPressIn: undefined,
+  onPressOut: undefined,
+  onLongPress: undefined,
+  delayPressIn: undefined,
+  delayPressOut: undefined,
+  delayLongPress: undefined,
+  pressRetentionOffset: undefined,
+  hitSlop: undefined
+};

--- a/src/components/__snapshots__/Button.test.js.snap
+++ b/src/components/__snapshots__/Button.test.js.snap
@@ -1,15 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<TouchableOpacity
-  activeOpacity={0.2}
+<Touchable
+  accessibilityComponentType="button"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  delayPressIn={50}
   onPress={[Function]}
   style={
     Object {
       "alignItems": "center",
       "backgroundColor": "#D8D8D8",
       "borderRadius": 4,
-      "height": 40,
       "justifyContent": "center",
     }
   }
@@ -25,5 +30,5 @@ exports[`renders correctly 1`] = `
   >
     a button
   </Text>
-</TouchableOpacity>
+</Touchable>
 `;

--- a/src/components/__snapshots__/CheckBox.test.js.snap
+++ b/src/components/__snapshots__/CheckBox.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<TouchableOpacity
+<Touchable
   accessibilityComponentType="radiobutton_unchecked"
   accessibilityTraits={
     Array [
       "button",
     ]
   }
-  activeOpacity={0.2}
+  delayPressIn={50}
   onPress={[Function]}
   style={
     Array [
@@ -28,11 +28,11 @@ exports[`renders correctly 1`] = `
   >
     Bananas
   </Text>
-</TouchableOpacity>
+</Touchable>
 `;
 
 exports[`renders correctly when checked 1`] = `
-<TouchableOpacity
+<Touchable
   accessibilityComponentType="radiobutton_checked"
   accessibilityTraits={
     Array [
@@ -40,7 +40,7 @@ exports[`renders correctly when checked 1`] = `
       "selected",
     ]
   }
-  activeOpacity={0.2}
+  delayPressIn={50}
   onPress={[Function]}
   style={
     Array [
@@ -63,5 +63,5 @@ exports[`renders correctly when checked 1`] = `
   <Image
     source={1}
   />
-</TouchableOpacity>
+</Touchable>
 `;

--- a/src/components/__snapshots__/DateRangePickerDialog.test.js.snap
+++ b/src/components/__snapshots__/DateRangePickerDialog.test.js.snap
@@ -4,15 +4,25 @@ exports[`renders correctly with date selection 1`] = `
 <Dialog
   applyButtonText="Apply"
   headerRight={
-    <TouchableOpacity
+    <Touchable
       accessibilityComponentType="button"
       accessibilityTraits={
         Array [
           "button",
         ]
       }
-      activeOpacity={0.2}
+      accessible={undefined}
+      delayLongPress={undefined}
+      delayPressIn={50}
+      delayPressOut={undefined}
+      disabled={undefined}
+      hitSlop={undefined}
+      onLongPress={undefined}
       onPress={[Function]}
+      onPressIn={undefined}
+      onPressOut={undefined}
+      pressRetentionOffset={undefined}
+      style={undefined}
     >
       <Text
         markdown={false}
@@ -21,7 +31,7 @@ exports[`renders correctly with date selection 1`] = `
       >
         Clear
       </Text>
-    </TouchableOpacity>
+    </Touchable>
   }
   onApply={[Function]}
   onCancel={[Function]}
@@ -39,15 +49,25 @@ exports[`renders correctly without date selection 1`] = `
 <Dialog
   applyButtonText="Apply"
   headerRight={
-    <TouchableOpacity
+    <Touchable
       accessibilityComponentType="button"
       accessibilityTraits={
         Array [
           "button",
         ]
       }
-      activeOpacity={0.2}
+      accessible={undefined}
+      delayLongPress={undefined}
+      delayPressIn={50}
+      delayPressOut={undefined}
+      disabled={undefined}
+      hitSlop={undefined}
+      onLongPress={undefined}
       onPress={[Function]}
+      onPressIn={undefined}
+      onPressOut={undefined}
+      pressRetentionOffset={undefined}
+      style={undefined}
     >
       <Text
         markdown={false}
@@ -56,7 +76,7 @@ exports[`renders correctly without date selection 1`] = `
       >
         Clear
       </Text>
-    </TouchableOpacity>
+    </Touchable>
   }
   onApply={[Function]}
   onCancel={[Function]}

--- a/src/components/__snapshots__/Dialog.test.js.snap
+++ b/src/components/__snapshots__/Dialog.test.js.snap
@@ -84,14 +84,14 @@ exports[`renders correctly 1`] = `
       </View>
       Lorem Ipsum is placeholder text commonly used...
     </View>
-    <TouchableOpacity
+    <Touchable
       accessibilityComponentType="button"
       accessibilityTraits={
         Array [
           "button",
         ]
       }
-      activeOpacity={0.2}
+      delayPressIn={50}
       onPress={[Function]}
       style={
         Object {
@@ -115,7 +115,7 @@ exports[`renders correctly 1`] = `
       >
         Bye
       </Text>
-    </TouchableOpacity>
+    </Touchable>
   </View>
 </Component>
 `;

--- a/src/components/__snapshots__/EventCard.test.js.snap
+++ b/src/components/__snapshots__/EventCard.test.js.snap
@@ -4,7 +4,6 @@ exports[`renders correctly when isFree is false and there is a price range 1`] =
 <View
   style={
     Object {
-      "backgroundColor": "rgb(255, 255, 255)",
       "borderRadius": 5,
       "flexDirection": "row",
       "height": 108,
@@ -111,7 +110,6 @@ exports[`renders correctly when isFree is false and there's only one price 1`] =
 <View
   style={
     Object {
-      "backgroundColor": "rgb(255, 255, 255)",
       "borderRadius": 5,
       "flexDirection": "row",
       "height": 108,
@@ -218,7 +216,6 @@ exports[`renders correctly when isFree is true 1`] = `
 <View
   style={
     Object {
-      "backgroundColor": "rgb(255, 255, 255)",
       "borderRadius": 5,
       "flexDirection": "row",
       "height": 108,

--- a/src/components/__snapshots__/EventTile.test.js.snap
+++ b/src/components/__snapshots__/EventTile.test.js.snap
@@ -4,7 +4,6 @@ exports[`renders correctly 1`] = `
 <View
   style={
     Object {
-      "backgroundColor": "rgb(255, 255, 255)",
       "flexDirection": "column",
       "overflow": "hidden",
     }

--- a/src/components/__snapshots__/FilterHeaderButton.test.js.snap
+++ b/src/components/__snapshots__/FilterHeaderButton.test.js.snap
@@ -1,23 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<TouchableOpacity
+<Touchable
   accessibilityComponentType="button"
   accessibilityTraits={
     Array [
       "button",
     ]
   }
-  activeOpacity={0.2}
+  delayPressIn={50}
   onPress={[Function]}
   style={
     Array [
       Object {
         "alignItems": "center",
-        "borderColor": "rgb(44, 218, 157)",
-        "borderRadius": 4,
-        "borderWidth": 1,
-        "height": 32,
         "justifyContent": "center",
         "paddingHorizontal": 8,
       },
@@ -32,11 +28,12 @@ exports[`renders correctly 1`] = `
     style={
       Object {
         "color": "rgb(44, 218, 157)",
+        "fontFamily": "Roboto-Medium",
       }
     }
     type="text"
   >
     1-2-3 filtered
   </Text>
-</TouchableOpacity>
+</Touchable>
 `;

--- a/src/components/__snapshots__/Touchable.android.test.js.snap
+++ b/src/components/__snapshots__/Touchable.android.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<TouchableNativeFeedback
+  accessibilityComponentType="button"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  background="mock background"
+>
+  <View
+    style={
+      Array [
+        Object {
+          "color": "red",
+        },
+        Object {
+          "borderRadius": 2,
+        },
+      ]
+    }
+  >
+    Hello
+  </View>
+</TouchableNativeFeedback>
+`;

--- a/src/components/__snapshots__/Touchable.ios.test.js.snap
+++ b/src/components/__snapshots__/Touchable.ios.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<TouchableOpacity
+  accessibilityComponentType="button"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  activeOpacity={0.2}
+  delayPressIn={50}
+  style={
+    Array [
+      Object {
+        "justifyContent": "center",
+        "minHeight": 44,
+        "minWidth": 44,
+      },
+      Object {
+        "borderRadius": 2,
+      },
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    Hello
+  </Text>
+</TouchableOpacity>
+`;

--- a/src/screens/EventDetailsScreen/EventMap.js
+++ b/src/screens/EventDetailsScreen/EventMap.js
@@ -1,8 +1,9 @@
 // @flow
 import React from "react";
-import { TouchableOpacity, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import MapView, { Marker } from "react-native-maps";
 import showLocation from "./openMapLink";
+import Touchable from "../../components/Touchable";
 
 type Props = {
   lat: number,
@@ -11,7 +12,7 @@ type Props = {
 };
 
 const EventMap = ({ lat, lon, locationName }: Props) => (
-  <TouchableOpacity
+  <Touchable
     style={styles.mapWrapper}
     onPress={() => showLocation(lat, lon, locationName)}
   >
@@ -34,7 +35,7 @@ const EventMap = ({ lat, lon, locationName }: Props) => (
         }}
       />
     </MapView>
-  </TouchableOpacity>
+  </Touchable>
 );
 
 const styles = StyleSheet.create({

--- a/src/screens/EventDetailsScreen/Header.js
+++ b/src/screens/EventDetailsScreen/Header.js
@@ -1,13 +1,8 @@
 // @flow
 import React from "react";
-import {
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  StatusBar,
-  ImageBackground
-} from "react-native";
+import { Text, StyleSheet, StatusBar, ImageBackground } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
+import Touchable from "../../components/Touchable";
 
 type Props = {
   onBackButtonPress: () => void,
@@ -20,11 +15,11 @@ const Header = ({ onBackButtonPress, imageUrl }: Props) => (
     source={{ uri: imageUrl }}
     resizeMode="cover"
   >
-    <SafeAreaView style={styles.content}>
+    <SafeAreaView>
       <StatusBar barStyle="default" animated />
-      <TouchableOpacity onPress={onBackButtonPress}>
+      <Touchable onPress={onBackButtonPress} style={styles.backButton}>
         <Text>Back</Text>
-      </TouchableOpacity>
+      </Touchable>
     </SafeAreaView>
   </ImageBackground>
 );
@@ -34,8 +29,8 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 180
   },
-  content: {
-    padding: 22
+  backButton: {
+    padding: 8
   }
 });
 

--- a/src/screens/EventDetailsScreen/Header.test.js
+++ b/src/screens/EventDetailsScreen/Header.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import Header from "./Header";
+import Touchable from "../../components/Touchable";
 
 it("renders correctly", () => {
   const output = shallow(
@@ -16,7 +17,7 @@ it("calls callback when pressed", () => {
     <Header onBackButtonPress={onPress} imageUrl="https://image.jpg" />
   );
 
-  const touchable = output.find("TouchableOpacity");
+  const touchable = output.find(Touchable);
   touchable.simulate("press");
 
   expect(onPress).toHaveBeenCalled();

--- a/src/screens/EventDetailsScreen/__snapshots__/EventMap.test.js.snap
+++ b/src/screens/EventDetailsScreen/__snapshots__/EventMap.test.js.snap
@@ -1,8 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<TouchableOpacity
-  activeOpacity={0.2}
+<Touchable
+  accessibilityComponentType="button"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  delayPressIn={50}
   onPress={[Function]}
   style={
     Object {
@@ -39,5 +45,5 @@ exports[`renders correctly 1`] = `
       onPress={[Function]}
     />
   </MapView>
-</TouchableOpacity>
+</Touchable>
 `;

--- a/src/screens/EventDetailsScreen/__snapshots__/Header.test.js.snap
+++ b/src/screens/EventDetailsScreen/__snapshots__/Header.test.js.snap
@@ -15,21 +15,26 @@ exports[`renders correctly 1`] = `
     }
   }
 >
-  <withOrientation
-    style={
-      Object {
-        "padding": 22,
-      }
-    }
-  >
+  <withOrientation>
     <StatusBar
       animated={true}
       barStyle="default"
       showHideTransition="fade"
     />
-    <TouchableOpacity
-      activeOpacity={0.2}
+    <Touchable
+      accessibilityComponentType="button"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      delayPressIn={50}
       onPress={[Function]}
+      style={
+        Object {
+          "padding": 8,
+        }
+      }
     >
       <Text
         accessible={true}
@@ -38,7 +43,7 @@ exports[`renders correctly 1`] = `
       >
         Back
       </Text>
-    </TouchableOpacity>
+    </Touchable>
   </withOrientation>
 </ImageBackground>
 `;

--- a/src/screens/HomeScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/HomeScreen/__snapshots__/component.test.js.snap
@@ -52,22 +52,15 @@ exports[`HomeScreen Component renders correctly 1`] = `
       >
         Featured events
       </Text>
-      <TouchableOpacity
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         onPress={[Function]}
-        style={
-          Object {
-            "justifyContent": "center",
-            "minHeight": 44,
-          }
-        }
         testID="view-all"
       >
         <Text
@@ -81,7 +74,7 @@ exports[`HomeScreen Component renders correctly 1`] = `
         >
           View all
         </Text>
-      </TouchableOpacity>
+      </Touchable>
     </View>
     <View
       style={
@@ -93,14 +86,13 @@ exports[`HomeScreen Component renders correctly 1`] = `
         }
       }
     >
-      <TouchableOpacity
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="1"
         onPress={[Function]}
@@ -118,15 +110,14 @@ exports[`HomeScreen Component renders correctly 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="2"
         onPress={[Function]}
@@ -144,15 +135,14 @@ exports[`HomeScreen Component renders correctly 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="3"
         onPress={[Function]}
@@ -170,15 +160,14 @@ exports[`HomeScreen Component renders correctly 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="4"
         onPress={[Function]}
@@ -196,7 +185,7 @@ exports[`HomeScreen Component renders correctly 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
+      </Touchable>
     </View>
   </ScrollView>
 </SafeAreaView>
@@ -254,22 +243,15 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
       >
         Featured events
       </Text>
-      <TouchableOpacity
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         onPress={[Function]}
-        style={
-          Object {
-            "justifyContent": "center",
-            "minHeight": 44,
-          }
-        }
         testID="view-all"
       >
         <Text
@@ -283,7 +265,7 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
         >
           View all
         </Text>
-      </TouchableOpacity>
+      </Touchable>
     </View>
     <View
       style={
@@ -295,14 +277,13 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
         }
       }
     >
-      <TouchableOpacity
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="1"
         onPress={[Function]}
@@ -320,15 +301,14 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="2"
         onPress={[Function]}
@@ -346,15 +326,14 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="3"
         onPress={[Function]}
@@ -372,15 +351,14 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="4"
         onPress={[Function]}
@@ -398,15 +376,14 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="5"
         onPress={[Function]}
@@ -424,15 +401,14 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
-      <TouchableOpacity
+      </Touchable>
+      <Touchable
         accessibilityComponentType="button"
         accessibilityTraits={
           Array [
             "button",
           ]
         }
-        activeOpacity={0.2}
         delayPressIn={50}
         key="6"
         onPress={[Function]}
@@ -450,7 +426,7 @@ exports[`HomeScreen Component renders max 6 events 1`] = `
           imageUrl="http://example.com/image.png"
           name="some other"
         />
-      </TouchableOpacity>
+      </Touchable>
     </View>
   </ScrollView>
 </SafeAreaView>

--- a/src/screens/HomeScreen/component.js
+++ b/src/screens/HomeScreen/component.js
@@ -1,16 +1,11 @@
 // @flow
 import React, { PureComponent } from "react";
-import {
-  StyleSheet,
-  SafeAreaView,
-  ScrollView,
-  View,
-  TouchableOpacity
-} from "react-native";
+import { StyleSheet, SafeAreaView, ScrollView, View } from "react-native";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
 import Text from "../../components/Text";
 import type { Event, LocalizedFieldRef } from "../../data/event";
 import EventTile from "../../components/EventTile";
+import Touchable from "../../components/Touchable";
 import {
   cardBgColor,
   imageBgColor,
@@ -63,26 +58,16 @@ class HomeScreen extends PureComponent<Props> {
             <Text type="h2" style={{ color: titleTextColor }}>
               {this.props.featuredEventsTitle}
             </Text>
-            <TouchableOpacity
-              style={styles.sectionTitleButton}
-              onPress={this.eventList}
-              accessibilityTraits={["button"]}
-              accessibilityComponentType="button"
-              delayPressIn={50}
-              testID="view-all"
-            >
+            <Touchable onPress={this.eventList} testID="view-all">
               <Text style={{ color: titleTextColor }}>View all</Text>
-            </TouchableOpacity>
+            </Touchable>
           </View>
           <View style={styles.container}>
             {events.map(event => (
-              <TouchableOpacity
+              <Touchable
                 key={event.sys.id}
                 style={styles.tile}
                 onPress={() => this.eventDetails(event.sys.id)}
-                accessibilityTraits={["button"]}
-                accessibilityComponentType="button"
-                delayPressIn={50}
                 testID={`event-tile-${event.sys.id}`}
               >
                 <EventTile
@@ -92,7 +77,7 @@ class HomeScreen extends PureComponent<Props> {
                     event.fields.eventsListPicture
                   )}
                 />
-              </TouchableOpacity>
+              </Touchable>
             ))}
           </View>
         </ScrollView>
@@ -118,10 +103,6 @@ const styles = StyleSheet.create({
     marginBottom: 6,
     justifyContent: "space-between",
     alignItems: "center"
-  },
-  sectionTitleButton: {
-    minHeight: 44,
-    justifyContent: "center"
   },
   container: {
     flex: 1,


### PR DESCRIPTION
## Features

-   Enforce best practices for accessibility
    - Min touch area: 44x44
    - Accessibility attribute "button"
-   Use native feedback for Android
-   Offer all props of `TouchableWithoutFeedback` to make it easy to use in all places.

## Caveats

-   The native feedback for Android is hidden when views inside the button have a background color set.