### PR TITLE
Create "staged" filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "react-native-mock": "^0.3.1",
     "react-native-schemes-manager": "^1.0.1",
     "react-native-version": "^2.4.1",
-    "react-test-renderer": "16.2.0"
+    "react-test-renderer": "16.2.0",
+    "redux-mock-store": "^1.5.1"
   },
   "resolutions": {
     "react-native-safe-area-view": "robbiemccorkell/react-native-safe-area-view"

--- a/src/actions/event-filters.js
+++ b/src/actions/event-filters.js
@@ -2,7 +2,10 @@
 import type { DateOrDateRange, Time } from "../data/date-time";
 import type { StandardAction } from "./";
 
-type EventFiltersActionType = "UPDATE_EVENT_FILTERS";
+type EventFiltersActionType =
+  | "STAGE_EVENT_FILTERS"
+  | "COMMIT_EVENT_FILTERS"
+  | "CLEAR_STAGED_EVENT_FILTERS";
 type EventFiltersPayload = {
   date?: ?DateOrDateRange,
   time?: Set<Time>
@@ -13,12 +16,19 @@ export type EventFiltersAction = StandardAction<
   EventFiltersPayload
 >;
 
-/* eslint-disable import/prefer-default-export */
-export const updateEventFilters = (updates: EventFiltersPayload) => (
+export const stageEventFilters = (updates: EventFiltersPayload) => (
   dispatch: Dispatch<EventFiltersAction>
 ) => {
   dispatch({
-    type: "UPDATE_EVENT_FILTERS",
+    type: "STAGE_EVENT_FILTERS",
     payload: updates
   });
 };
+
+export const commitEventFilters = () => (
+  dispatch: Dispatch<EventFiltersAction>
+) => dispatch({ type: "COMMIT_EVENT_FILTERS" });
+
+export const clearStagedEventFilters = () => (
+  dispatch: Dispatch<EventFiltersAction>
+) => dispatch({ type: "CLEAR_STAGED_EVENT_FILTERS" });

--- a/src/actions/event-filters.test.js
+++ b/src/actions/event-filters.test.js
@@ -1,6 +1,10 @@
-import { updateEventFilters } from "./event-filters";
+import {
+  stageEventFilters,
+  commitEventFilters,
+  clearStagedEventFilters
+} from "./event-filters";
 
-describe("updateEventFilters", () => {
+describe("stageEventFilters", () => {
   it("calls correct action with expected payload", async () => {
     const updates = {
       date: "2018-02-02",
@@ -8,11 +12,35 @@ describe("updateEventFilters", () => {
     };
     const mockDispatch = jest.fn();
 
-    await updateEventFilters(updates)(mockDispatch);
+    await stageEventFilters(updates)(mockDispatch);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: "UPDATE_EVENT_FILTERS",
+      type: "STAGE_EVENT_FILTERS",
       payload: updates
+    });
+  });
+});
+
+describe("commitEventFilters", () => {
+  it("calls correct action with expected payload", async () => {
+    const mockDispatch = jest.fn();
+
+    await commitEventFilters()(mockDispatch);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "COMMIT_EVENT_FILTERS"
+    });
+  });
+});
+
+describe("clearStagedEventFilters", () => {
+  it("calls correct action with expected payload", async () => {
+    const mockDispatch = jest.fn();
+
+    await clearStagedEventFilters()(mockDispatch);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "CLEAR_STAGED_EVENT_FILTERS"
     });
   });
 });

--- a/src/components/ConnectedDateFilterDialog.js
+++ b/src/components/ConnectedDateFilterDialog.js
@@ -1,7 +1,11 @@
 // @flow
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
-import { updateEventFilters } from "../actions/event-filters";
+import {
+  stageEventFilters,
+  commitEventFilters,
+  clearStagedEventFilters
+} from "../actions/event-filters";
 import type { DateOrDateRange } from "../data/date-time";
 import { selectFilteredEvents } from "../selectors/events";
 import { selectDateFilter } from "../selectors/event-filters";
@@ -21,13 +25,23 @@ type Props = {
 } & OwnProps;
 
 const mapStateToProps = state => ({
-  applyButtonText: text.filterPickerApply(selectFilteredEvents(state).length),
-  dateRange: selectDateFilter(state)
+  applyButtonText: text.filterPickerApply(
+    selectFilteredEvents(state, true).length
+  ),
+  dateRange: selectDateFilter(state, true)
 });
 
-const mapDispatchToProps = {
-  onChange: date => updateEventFilters({ date })
-};
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  onChange: date => dispatch(stageEventFilters({ date })),
+  onApply: () => {
+    ownProps.onApply();
+    dispatch(commitEventFilters());
+  },
+  onCancel: () => {
+    ownProps.onCancel();
+    dispatch(clearStagedEventFilters());
+  }
+});
 
 const connector: Connector<OwnProps, Props> = connect(
   mapStateToProps,

--- a/src/components/ConnectedDateFilterDialog.test.js
+++ b/src/components/ConnectedDateFilterDialog.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
 import { shallow } from "enzyme";
 import ConnectedDateFilterDialog from "./ConnectedDateFilterDialog";
 
@@ -23,7 +24,7 @@ const initialState = {
     }
   }
 };
-const mockStore = configureStore();
+const mockStore = configureStore([thunk]);
 
 describe("ConnectedDateFilterDialog", () => {
   it("renders connector", () => {
@@ -50,5 +51,73 @@ describe("ConnectedDateFilterDialog", () => {
       />
     );
     expect(output.dive()).toMatchSnapshot();
+  });
+
+  it("commits filters on apply", () => {
+    const store = mockStore(initialState);
+    const mockOnApply = jest.fn();
+    const output = shallow(
+      <ConnectedDateFilterDialog
+        store={store}
+        onApply={mockOnApply}
+        onCancel={() => {}}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .props()
+      .onApply();
+    const actions = store.getActions();
+
+    expect(mockOnApply).toHaveBeenCalled();
+    expect(actions).toEqual([{ type: "COMMIT_EVENT_FILTERS" }]);
+  });
+
+  it("clears filters on cancel", () => {
+    const store = mockStore(initialState);
+    const mockOnCancel = jest.fn();
+    const output = shallow(
+      <ConnectedDateFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={mockOnCancel}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .props()
+      .onCancel();
+    const actions = store.getActions();
+
+    expect(mockOnCancel).toHaveBeenCalled();
+    expect(actions).toEqual([{ type: "CLEAR_STAGED_EVENT_FILTERS" }]);
+  });
+
+  it("updates filters on change", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedDateFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .find("DateRangePicker")
+      .props()
+      .onChange("2018-02-02");
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual([
+      { type: "STAGE_EVENT_FILTERS", payload: { date: "2018-02-02" } }
+    ]);
   });
 });

--- a/src/components/ConnectedDateFilterDialog.test.js
+++ b/src/components/ConnectedDateFilterDialog.test.js
@@ -1,0 +1,54 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { shallow } from "enzyme";
+import ConnectedDateFilterDialog from "./ConnectedDateFilterDialog";
+
+const initialState = {
+  events: {
+    entries: [],
+    assets: [],
+    loading: true,
+    refreshing: false
+  },
+  eventFilters: {
+    selectedFilters: {
+      categories: new Set(),
+      date: null,
+      time: new Set()
+    },
+    stagedFilters: {
+      categories: new Set(),
+      date: null,
+      time: new Set()
+    }
+  }
+};
+const mockStore = configureStore();
+
+describe("ConnectedDateFilterDialog", () => {
+  it("renders connector", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedDateFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it("renders component", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedDateFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+    expect(output.dive()).toMatchSnapshot();
+  });
+});

--- a/src/components/ConnectedTimeFilterDialog.js
+++ b/src/components/ConnectedTimeFilterDialog.js
@@ -1,7 +1,11 @@
 // @flow
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
-import { updateEventFilters } from "../actions/event-filters";
+import {
+  stageEventFilters,
+  commitEventFilters,
+  clearStagedEventFilters
+} from "../actions/event-filters";
 import { selectFilteredEvents } from "../selectors/events";
 import { selectTimeFilter } from "../selectors/event-filters";
 import Component from "./MultiSelectDialog";
@@ -24,20 +28,32 @@ type Props = {
 } & OwnProps;
 
 const mapStateToProps = state => ({
-  applyButtonText: text.filterPickerApply(selectFilteredEvents(state).length),
+  applyButtonText: text.filterPickerApply(
+    selectFilteredEvents(state, true).length
+  ),
   options: OPTIONS.map(option => text.time[option]),
-  selectedIndexes: Array.from(selectTimeFilter(state)).map(time =>
+  selectedIndexes: Array.from(selectTimeFilter(state, true)).map(time =>
     OPTIONS.indexOf(time)
   ),
   title: text.filterTimePickerTitle
 });
 
-const mapDispatchToProps = {
+const mapDispatchToProps = (dispatch, ownProps) => ({
   onChange: selectedIndexes =>
-    updateEventFilters({
-      time: new Set(selectedIndexes.map(index => OPTIONS[index]))
-    })
-};
+    dispatch(
+      stageEventFilters({
+        time: new Set(selectedIndexes.map(index => OPTIONS[index]))
+      })
+    ),
+  onApply: () => {
+    ownProps.onApply();
+    dispatch(commitEventFilters());
+  },
+  onCancel: () => {
+    ownProps.onCancel();
+    dispatch(clearStagedEventFilters());
+  }
+});
 
 const connector: Connector<OwnProps, Props> = connect(
   mapStateToProps,

--- a/src/components/ConnectedTimeFilterDialog.test.js
+++ b/src/components/ConnectedTimeFilterDialog.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
 import { shallow } from "enzyme";
-import ConnectedTimeFilterDialog from "./ConnectedDateFilterDialog";
+import ConnectedTimeFilterDialog from "./ConnectedTimeFilterDialog";
 
 const initialState = {
   events: {
@@ -110,14 +110,15 @@ describe("ConnectedTimeFilterDialog", () => {
 
     output
       .dive()
-      .find("DateRangePicker")
+      .find("CheckBox")
+      .first()
       .props()
-      .onChange("2018-02-02");
+      .onChange();
 
     const actions = store.getActions();
 
-    expect(actions).toEqual([
-      { type: "STAGE_EVENT_FILTERS", payload: { date: "2018-02-02" } }
-    ]);
+    expect(actions[0]).toEqual(
+      expect.objectContaining({ type: "STAGE_EVENT_FILTERS" })
+    );
   });
 });

--- a/src/components/ConnectedTimeFilterDialog.test.js
+++ b/src/components/ConnectedTimeFilterDialog.test.js
@@ -1,0 +1,54 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { shallow } from "enzyme";
+import ConnectedTimeFilterDialog from "./ConnectedDateFilterDialog";
+
+const initialState = {
+  events: {
+    entries: [],
+    assets: [],
+    loading: true,
+    refreshing: false
+  },
+  eventFilters: {
+    selectedFilters: {
+      categories: new Set(),
+      date: null,
+      time: new Set()
+    },
+    stagedFilters: {
+      categories: new Set(),
+      date: null,
+      time: new Set()
+    }
+  }
+};
+const mockStore = configureStore();
+
+describe("ConnectedTimeFilterDialog", () => {
+  it("renders connector", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedTimeFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it("renders component", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedTimeFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+    expect(output.dive()).toMatchSnapshot();
+  });
+});

--- a/src/components/ConnectedTimeFilterDialog.test.js
+++ b/src/components/ConnectedTimeFilterDialog.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
 import { shallow } from "enzyme";
 import ConnectedTimeFilterDialog from "./ConnectedDateFilterDialog";
 
@@ -23,7 +24,7 @@ const initialState = {
     }
   }
 };
-const mockStore = configureStore();
+const mockStore = configureStore([thunk]);
 
 describe("ConnectedTimeFilterDialog", () => {
   it("renders connector", () => {
@@ -50,5 +51,73 @@ describe("ConnectedTimeFilterDialog", () => {
       />
     );
     expect(output.dive()).toMatchSnapshot();
+  });
+
+  it("commits filters on apply", () => {
+    const store = mockStore(initialState);
+    const mockOnApply = jest.fn();
+    const output = shallow(
+      <ConnectedTimeFilterDialog
+        store={store}
+        onApply={mockOnApply}
+        onCancel={() => {}}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .props()
+      .onApply();
+    const actions = store.getActions();
+
+    expect(mockOnApply).toHaveBeenCalled();
+    expect(actions).toEqual([{ type: "COMMIT_EVENT_FILTERS" }]);
+  });
+
+  it("clears filters on cancel", () => {
+    const store = mockStore(initialState);
+    const mockOnCancel = jest.fn();
+    const output = shallow(
+      <ConnectedTimeFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={mockOnCancel}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .props()
+      .onCancel();
+    const actions = store.getActions();
+
+    expect(mockOnCancel).toHaveBeenCalled();
+    expect(actions).toEqual([{ type: "CLEAR_STAGED_EVENT_FILTERS" }]);
+  });
+
+  it("updates filters on change", () => {
+    const store = mockStore(initialState);
+    const output = shallow(
+      <ConnectedTimeFilterDialog
+        store={store}
+        onApply={() => {}}
+        onCancel={() => {}}
+        visible
+      />
+    );
+
+    output
+      .dive()
+      .find("DateRangePicker")
+      .props()
+      .onChange("2018-02-02");
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual([
+      { type: "STAGE_EVENT_FILTERS", payload: { date: "2018-02-02" } }
+    ]);
   });
 });

--- a/src/components/__snapshots__/ConnectedDateFilterDialog.test.js.snap
+++ b/src/components/__snapshots__/ConnectedDateFilterDialog.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectedDateFilterDialog renders component 1`] = `
+<Dialog
+  applyButtonText="Show 0 events"
+  headerRight={
+    <Touchable
+      accessibilityComponentType="button"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={undefined}
+      delayLongPress={undefined}
+      delayPressIn={50}
+      delayPressOut={undefined}
+      disabled={undefined}
+      hitSlop={undefined}
+      onLongPress={undefined}
+      onPress={[Function]}
+      onPressIn={undefined}
+      onPressOut={undefined}
+      pressRetentionOffset={undefined}
+      style={undefined}
+    >
+      <Text
+        markdown={false}
+        style={Object {}}
+        type="text"
+      >
+        Clear
+      </Text>
+    </Touchable>
+  }
+  onApply={[Function]}
+  onCancel={[Function]}
+  title="Select dates"
+  visible={true}
+>
+  <DateRangePicker
+    dateRange={null}
+    onChange={[Function]}
+  />
+</Dialog>
+`;
+
+exports[`ConnectedDateFilterDialog renders connector 1`] = `
+<DateRangePickerDialog
+  applyButtonText="Show 0 events"
+  dateRange={null}
+  onApply={[Function]}
+  onCancel={[Function]}
+  onChange={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  visible={true}
+/>
+`;

--- a/src/components/__snapshots__/ConnectedTimeFilterDialog.test.js.snap
+++ b/src/components/__snapshots__/ConnectedTimeFilterDialog.test.js.snap
@@ -3,55 +3,64 @@
 exports[`ConnectedTimeFilterDialog renders component 1`] = `
 <Dialog
   applyButtonText="Show 0 events"
-  headerRight={
-    <Touchable
-      accessibilityComponentType="button"
-      accessibilityTraits={
-        Array [
-          "button",
-        ]
-      }
-      accessible={undefined}
-      delayLongPress={undefined}
-      delayPressIn={50}
-      delayPressOut={undefined}
-      disabled={undefined}
-      hitSlop={undefined}
-      onLongPress={undefined}
-      onPress={[Function]}
-      onPressIn={undefined}
-      onPressOut={undefined}
-      pressRetentionOffset={undefined}
-      style={undefined}
-    >
-      <Text
-        markdown={false}
-        style={Object {}}
-        type="text"
-      >
-        Clear
-      </Text>
-    </Touchable>
-  }
   onApply={[Function]}
   onCancel={[Function]}
-  title="Select dates"
+  title="Select time"
   visible={true}
 >
-  <DateRangePicker
-    dateRange={null}
+  <CheckBox
+    checked={false}
+    key="Morning"
+    label="Morning"
     onChange={[Function]}
+    style={
+      Object {
+        "height": 48,
+        "paddingHorizontal": 16,
+      }
+    }
+  />
+  <CheckBox
+    checked={false}
+    key="Afternoon"
+    label="Afternoon"
+    onChange={[Function]}
+    style={
+      Object {
+        "height": 48,
+        "paddingHorizontal": 16,
+      }
+    }
+  />
+  <CheckBox
+    checked={false}
+    key="Evening"
+    label="Evening"
+    onChange={[Function]}
+    style={
+      Object {
+        "height": 48,
+        "paddingHorizontal": 16,
+      }
+    }
   />
 </Dialog>
 `;
 
 exports[`ConnectedTimeFilterDialog renders connector 1`] = `
-<DateRangePickerDialog
+<MultiSelectDialog
   applyButtonText="Show 0 events"
-  dateRange={null}
   onApply={[Function]}
   onCancel={[Function]}
   onChange={[Function]}
+  options={
+    Array [
+      "Morning",
+      "Afternoon",
+      "Evening",
+    ]
+  }
+  selectedIndexes={Array []}
   store={
     Object {
       "clearActions": [Function],
@@ -83,6 +92,7 @@ exports[`ConnectedTimeFilterDialog renders connector 1`] = `
       "unsubscribe": [Function],
     }
   }
+  title="Select time"
   visible={true}
 />
 `;

--- a/src/components/__snapshots__/ConnectedTimeFilterDialog.test.js.snap
+++ b/src/components/__snapshots__/ConnectedTimeFilterDialog.test.js.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectedTimeFilterDialog renders component 1`] = `
+<Dialog
+  applyButtonText="Show 0 events"
+  headerRight={
+    <Touchable
+      accessibilityComponentType="button"
+      accessibilityTraits={
+        Array [
+          "button",
+        ]
+      }
+      accessible={undefined}
+      delayLongPress={undefined}
+      delayPressIn={50}
+      delayPressOut={undefined}
+      disabled={undefined}
+      hitSlop={undefined}
+      onLongPress={undefined}
+      onPress={[Function]}
+      onPressIn={undefined}
+      onPressOut={undefined}
+      pressRetentionOffset={undefined}
+      style={undefined}
+    >
+      <Text
+        markdown={false}
+        style={Object {}}
+        type="text"
+      >
+        Clear
+      </Text>
+    </Touchable>
+  }
+  onApply={[Function]}
+  onCancel={[Function]}
+  title="Select dates"
+  visible={true}
+>
+  <DateRangePicker
+    dateRange={null}
+    onChange={[Function]}
+  />
+</Dialog>
+`;
+
+exports[`ConnectedTimeFilterDialog renders connector 1`] = `
+<DateRangePickerDialog
+  applyButtonText="Show 0 events"
+  dateRange={null}
+  onApply={[Function]}
+  onCancel={[Function]}
+  onChange={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  visible={true}
+/>
+`;

--- a/src/reducers/__snapshots__/event-filters.test.js.snap
+++ b/src/reducers/__snapshots__/event-filters.test.js.snap
@@ -2,8 +2,10 @@
 
 exports[`Event filters reducer initialises with default state 1`] = `
 Object {
-  "categories": Set {},
-  "date": null,
-  "time": Set {},
+  "selectedFilters": Object {
+    "categories": Set {},
+    "date": null,
+    "time": Set {},
+  },
 }
 `;

--- a/src/reducers/__snapshots__/event-filters.test.js.snap
+++ b/src/reducers/__snapshots__/event-filters.test.js.snap
@@ -7,5 +7,10 @@ Object {
     "date": null,
     "time": Set {},
   },
+  "stagedFilters": Object {
+    "categories": Set {},
+    "date": null,
+    "time": Set {},
+  },
 }
 `;

--- a/src/reducers/event-filters.js
+++ b/src/reducers/event-filters.js
@@ -10,11 +10,17 @@ type FilterCollection = {
 };
 
 export type State = {
-  selectedFilters: FilterCollection
+  selectedFilters: FilterCollection,
+  stagedFilters: FilterCollection
 };
 
 const defaultState = {
   selectedFilters: {
+    categories: new Set(), // When this is empty it signifies no category filter.
+    date: null,
+    time: new Set()
+  },
+  stagedFilters: {
     categories: new Set(), // When this is empty it signifies no category filter.
     date: null,
     time: new Set()
@@ -26,13 +32,23 @@ const eventFilters: Reducer<State, EventFiltersAction> = (
   action: EventFiltersAction
 ) => {
   switch (action.type) {
-    case "UPDATE_EVENT_FILTERS":
+    case "STAGE_EVENT_FILTERS":
       return {
         ...state,
-        selectedFilters: {
-          ...state.selectedFilters,
+        stagedFilters: {
+          ...state.stagedFilters,
           ...action.payload
         }
+      };
+    case "COMMIT_EVENT_FILTERS":
+      return {
+        ...state,
+        selectedFilters: state.stagedFilters
+      };
+    case "CLEAR_STAGED_EVENT_FILTERS":
+      return {
+        ...state,
+        stagedFilters: state.selectedFilters
       };
     default:
       return state;

--- a/src/reducers/event-filters.js
+++ b/src/reducers/event-filters.js
@@ -3,16 +3,22 @@ import type { Reducer } from "redux";
 import type { DateOrDateRange, Time } from "../data/date-time";
 import type { EventFiltersAction } from "../actions/event-filters";
 
-export type State = {
+type FilterCollection = {
   date: ?DateOrDateRange,
   time: Set<Time>,
   categories: Set<string>
 };
 
+export type State = {
+  selectedFilters: FilterCollection
+};
+
 const defaultState = {
-  categories: new Set(), // When this is empty it signifies no category filter.
-  date: null,
-  time: new Set()
+  selectedFilters: {
+    categories: new Set(), // When this is empty it signifies no category filter.
+    date: null,
+    time: new Set()
+  }
 };
 
 const eventFilters: Reducer<State, EventFiltersAction> = (
@@ -23,7 +29,10 @@ const eventFilters: Reducer<State, EventFiltersAction> = (
     case "UPDATE_EVENT_FILTERS":
       return {
         ...state,
-        ...action.payload
+        selectedFilters: {
+          ...state.selectedFilters,
+          ...action.payload
+        }
       };
     default:
       return state;

--- a/src/reducers/event-filters.test.js
+++ b/src/reducers/event-filters.test.js
@@ -9,25 +9,72 @@ describe("Event filters reducer", () => {
     expect(state).toMatchSnapshot();
   });
 
-  it("updates state with filters from payload for UPDATE_EVENT_FILTERS action", () => {
+  it("updates state with filters from payload for STAGE_EVENT_FILTERS action", () => {
     const initialState = {
       selectedFilters: {
+        categories: new Set(),
+        date: null,
+        time: new Set()
+      },
+      stagedFilters: {
         categories: new Set(),
         date: null,
         time: new Set()
       }
     };
     const state = reducer(initialState, {
-      type: "UPDATE_EVENT_FILTERS",
+      type: "STAGE_EVENT_FILTERS",
       payload: {
         date: "2018-03-12"
       }
     });
 
-    expect(state.selectedFilters.categories).toBe(
-      initialState.selectedFilters.categories
+    expect(state.stagedFilters.categories).toBe(
+      initialState.stagedFilters.categories
     );
+    expect(state.stagedFilters.date).toBe("2018-03-12");
+    expect(state.stagedFilters.time).toBe(initialState.stagedFilters.time);
+  });
+
+  it("updates state with filters from payload for COMMIT_EVENT_FILTERS action", () => {
+    const initialState = {
+      selectedFilters: {
+        categories: new Set(),
+        date: null,
+        time: new Set()
+      },
+      stagedFilters: {
+        categories: new Set(),
+        date: "2018-03-12",
+        time: new Set()
+      }
+    };
+    const state = reducer(initialState, {
+      type: "COMMIT_EVENT_FILTERS"
+    });
+
+    expect(state.stagedFilters.date).toBe("2018-03-12");
     expect(state.selectedFilters.date).toBe("2018-03-12");
-    expect(state.selectedFilters.time).toBe(initialState.selectedFilters.time);
+  });
+
+  it("updates state with filters from payload for CLEAR_STAGED_EVENT_FILTERS action", () => {
+    const initialState = {
+      selectedFilters: {
+        categories: new Set(),
+        date: "2018-03-12",
+        time: new Set()
+      },
+      stagedFilters: {
+        categories: new Set(),
+        date: "2018-03-20",
+        time: new Set()
+      }
+    };
+    const state = reducer(initialState, {
+      type: "CLEAR_STAGED_EVENT_FILTERS"
+    });
+
+    expect(state.stagedFilters.date).toBe("2018-03-12");
+    expect(state.selectedFilters.date).toBe("2018-03-12");
   });
 });

--- a/src/reducers/event-filters.test.js
+++ b/src/reducers/event-filters.test.js
@@ -11,9 +11,11 @@ describe("Event filters reducer", () => {
 
   it("updates state with filters from payload for UPDATE_EVENT_FILTERS action", () => {
     const initialState = {
-      categories: new Set(),
-      date: null,
-      time: new Set()
+      selectedFilters: {
+        categories: new Set(),
+        date: null,
+        time: new Set()
+      }
     };
     const state = reducer(initialState, {
       type: "UPDATE_EVENT_FILTERS",
@@ -22,8 +24,10 @@ describe("Event filters reducer", () => {
       }
     });
 
-    expect(state.categories).toBe(initialState.categories);
-    expect(state.date).toBe("2018-03-12");
-    expect(state.time).toBe(initialState.time);
+    expect(state.selectedFilters.categories).toBe(
+      initialState.selectedFilters.categories
+    );
+    expect(state.selectedFilters.date).toBe("2018-03-12");
+    expect(state.selectedFilters.time).toBe(initialState.selectedFilters.time);
   });
 });

--- a/src/selectors/event-filters.js
+++ b/src/selectors/event-filters.js
@@ -8,7 +8,8 @@ import type { Event } from "../data/event";
 import type { DateOrDateRange, Time } from "../data/date-time";
 import type { State } from "../reducers";
 
-const getEventFiltersState = (state: State) => state.eventFilters;
+const getEventFiltersState = (state: State) =>
+  state.eventFilters.selectedFilters;
 
 export const selectDateFilter = (state: State) =>
   getEventFiltersState(state).date;

--- a/src/selectors/event-filters.js
+++ b/src/selectors/event-filters.js
@@ -8,13 +8,19 @@ import type { Event } from "../data/event";
 import type { DateOrDateRange, Time } from "../data/date-time";
 import type { State } from "../reducers";
 
-const getEventFiltersState = (state: State) =>
-  state.eventFilters.selectedFilters;
+const getEventFiltersState = (state: State, selectStagedFilters: boolean) =>
+  selectStagedFilters
+    ? state.eventFilters.stagedFilters
+    : state.eventFilters.selectedFilters;
 
-export const selectDateFilter = (state: State) =>
-  getEventFiltersState(state).date;
-export const selectTimeFilter = (state: State) =>
-  getEventFiltersState(state).time;
+export const selectDateFilter = (
+  state: State,
+  selectStagedFilters?: boolean = false
+) => getEventFiltersState(state, selectStagedFilters).date;
+export const selectTimeFilter = (
+  state: State,
+  selectStagedFilters?: boolean = false
+) => getEventFiltersState(state, selectStagedFilters).time;
 
 const buildDateOrDateRangeFilter = (date: DateOrDateRange) =>
   typeof date === "string" ? buildDateFilter(date) : buildDateRangeFilter(date);
@@ -24,8 +30,11 @@ const buildTimesFilter = (times: Time[]) => {
   return (event: Event) => filters.some(filter => filter(event));
 };
 
-export const buildEventFilter = (state: State) => {
-  const { date, time } = getEventFiltersState(state);
+export const buildEventFilter = (
+  state: State,
+  selectStagedFilters?: boolean = false
+) => {
+  const { date, time } = getEventFiltersState(state, selectStagedFilters);
   const timeArray = Array.from(time);
   const dateFilter: (event: Event) => boolean = date
     ? buildDateOrDateRangeFilter(date)

--- a/src/selectors/event-filters.test.js
+++ b/src/selectors/event-filters.test.js
@@ -35,9 +35,11 @@ const buildState = ({
     refreshing: false
   },
   eventFilters: {
-    date,
-    time,
-    categories
+    selectedFilters: {
+      date,
+      time,
+      categories
+    }
   }
 });
 
@@ -115,7 +117,7 @@ describe("buildEventFilter", () => {
     const filter = buildEventFilter(state);
     expect(filter(event)).toBe(true);
     expect(untypedBuildDateFilter).toHaveBeenCalledWith(
-      state.eventFilters.date
+      state.eventFilters.selectedFilters.date
     );
     expect(untypedBuildDateRangeFilter).not.toHaveBeenCalled();
   });
@@ -135,7 +137,7 @@ describe("buildEventFilter", () => {
     expect(filter(event)).toBe(true);
     expect(untypedBuildDateFilter).not.toHaveBeenCalled();
     expect(untypedBuildDateRangeFilter).toHaveBeenCalledWith(
-      state.eventFilters.date
+      state.eventFilters.selectedFilters.date
     );
   });
 

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -60,8 +60,10 @@ export const selectEventById = (state: State, id: string) =>
 export const selectAssetById = (state: State, id: string): Asset =>
   (selectAssets(state).find(asset => asset.sys.id === id): any);
 
-export const selectFilteredEvents = (state: State) =>
-  selectEvents(state).filter(buildEventFilter(state));
+export const selectFilteredEvents = (
+  state: State,
+  selectStagedFilters?: boolean = false
+) => selectEvents(state).filter(buildEventFilter(state, selectStagedFilters));
 
 export const selectFeaturedEventsByTitle = (state: State, title: string) => {
   const featured = selectFeaturedEvents(state).find(

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -346,7 +346,42 @@ describe("selectFilteredEvents", () => {
     const actual = selectFilteredEvents(state);
 
     expect(actual).toEqual(expected);
-    expect(buildEventFilter).toHaveBeenCalledWith(state);
+    expect(buildEventFilter).toHaveBeenCalledWith(state, false);
+    expect(mockFilter).toHaveBeenCalledTimes(2);
+  });
+
+  it("filters events using the buildEventFilter function with staged filters", () => {
+    const mockFilter = jest
+      .fn()
+      .mockReturnValue(false)
+      .mockReturnValueOnce(true);
+    buildEventFilter.mockReturnValue(mockFilter);
+
+    const state = {
+      events: {
+        entries: [
+          {
+            fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+            sys: { contentType: { sys: { id: "event" } } }
+          },
+          {
+            fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+            sys: { contentType: { sys: { id: "event" } } }
+          }
+        ]
+      }
+    };
+
+    const expected = [
+      {
+        fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+        sys: { contentType: { sys: { id: "event" } } }
+      }
+    ];
+    const actual = selectFilteredEvents(state, true);
+
+    expect(actual).toEqual(expected);
+    expect(buildEventFilter).toHaveBeenCalledWith(state, true);
     expect(mockFilter).toHaveBeenCalledTimes(2);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,6 +4612,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -6263,6 +6267,12 @@ redent@^2.0.0:
 redux-devtools-extension@^2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
+
+redux-mock-store@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This PR makes filters only take effect when a user confirms their choice, allowing for cancelling of currently selected filters.

Selected filters are now stored under a key in the `event-filters` reducer called `selectedFilters`.

- When a user opens a dialog and selects filters to apply, chosen filters are stored under a `stagedFilters` key.
- When the user taps the confirmation button a `COMMIT_EVENT_FILTERS` action fires, and the `selectedFilters` state is replaced with the `stagedFilters` state.
- If a user cancels a dialog (currently only supported on the Android hardware back button until #79 is finished), the `stagedFilters` state is replaced with the current `selectedFilters` state, clearing out any choices made since the last commit.

@charypar I haven't touched the filter UI components, and I've just rewired the already existing `onCancel` prop, so your #79 PR should still work.

This will help me complete #85, as it requires cancel functionality.

## Pre-flight check-list

Before raising a pull request

* ~~Documentation~~
* [x] Unit tests

## Pre-merge check-list

* ~~Tester approved~~

![](https://media.giphy.com/media/fDO2Nk0ImzvvW/giphy.gif)
