### PR TITLE
Switch dates if end date is before start date

### DIFF
--- a/e2e/init.js
+++ b/e2e/init.js
@@ -2,7 +2,7 @@ import detox from "detox";
 import { detox as config } from "../package.json";
 
 // Set the default test timeout of 120s
-jest.setTimeout(120000);
+jest.setTimeout(300000);
 
 beforeAll(async () => {
   await detox.init(config);

--- a/src/data/get-asset-url.js
+++ b/src/data/get-asset-url.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Asset, LocalizedFieldRef } from "./event";
 
-const locale = "en-GB";
+import locale from "../data/locale";
 
 export default (getAssetById: string => Asset) => (
   fieldRef: LocalizedFieldRef

--- a/src/data/locale.js
+++ b/src/data/locale.js
@@ -1,0 +1,1 @@
+export default "en-GB";

--- a/src/data/locale.test.js
+++ b/src/data/locale.test.js
@@ -1,0 +1,7 @@
+import locale from "./locale";
+
+describe("locale.js", () => {
+  it("locale exprts en-GB", () => {
+    expect(locale).toBe("en-GB");
+  });
+});

--- a/src/integrations/storage.test.js
+++ b/src/integrations/storage.test.js
@@ -201,3 +201,49 @@ describe("loadCmsData", () => {
     expect(loadedData).toEqual(mockData);
   });
 });
+
+describe("correctDates", () => {
+  it("switches dates if end date is before start date", async () => {
+    const cmsData = {
+      entries: [
+        {
+          sys: { id: "1" },
+          fields: {
+            startTime: { "en-GB": "2018-07-07T22:3001:00" },
+            endTime: { "en-GB": "2018-07-07T10:3001:00" }
+          }
+        }
+      ],
+      assets: [{ sys: { id: "1" } }],
+      deletedEntries: [],
+      deletedAssets: [],
+      nextSyncToken: "abc"
+    };
+    const mockLoadCmsData = async () => ({
+      entries: [],
+      assets: [],
+      syncToken: "123"
+    });
+    const mockAsyncStorage = { setItem: jest.fn() };
+    const expectedCmsData = {
+      entries: [
+        {
+          sys: { id: "1" },
+          fields: {
+            startTime: { "en-GB": "2018-07-07T10:3001:00" },
+            endTime: { "en-GB": "2018-07-07T22:3001:00" }
+          }
+        }
+      ],
+      assets: [{ sys: { id: "1" } }],
+      syncToken: "abc"
+    };
+
+    const savedCmsData = await saveCmsData(
+      cmsData,
+      mockLoadCmsData,
+      mockAsyncStorage
+    );
+    expect(savedCmsData).toEqual(expectedCmsData);
+  });
+});

--- a/src/screens/EventDetailsScreen/component.js
+++ b/src/screens/EventDetailsScreen/component.js
@@ -19,7 +19,7 @@ import text from "../../constants/text";
 import strings from "../../constants/strings";
 import type { Event, LocalizedFieldRef } from "../../data/event";
 
-const locale = "en-GB";
+import locale from "../../data/locale";
 
 type Props = {
   navigation: NavigationScreenProp<{ params: { eventId: string } }>,

--- a/src/screens/EventsScreen/component.js
+++ b/src/screens/EventsScreen/component.js
@@ -7,8 +7,7 @@ import EventList from "../../components/EventList";
 import FilterHeader from "../../components/ConnectedFilterHeader";
 import { bgColor } from "../../constants/colors";
 import { EVENT_DETAILS } from "../../constants/routes";
-
-const locale = "en-GB";
+import locale from "../../data/locale";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,

--- a/src/screens/FeaturedEventListScreen/component.js
+++ b/src/screens/FeaturedEventListScreen/component.js
@@ -7,7 +7,7 @@ import EventList from "../../components/EventList";
 import { bgColor } from "../../constants/colors";
 import { EVENT_DETAILS } from "../../constants/routes";
 
-const locale = "en-GB";
+import locale from "../../data/locale";
 
 type Props = {
   navigation: NavigationScreenProp<{ params: { title: string } }>,

--- a/src/screens/HomeScreen/component.js
+++ b/src/screens/HomeScreen/component.js
@@ -13,7 +13,7 @@ import {
 } from "../../constants/colors";
 import { FEATURED_EVENT_LIST, EVENT_DETAILS } from "../../constants/routes";
 
-const locale = "en-GB";
+import locale from "../../data/locale";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,

--- a/src/selectors/basic-event-filters.js
+++ b/src/selectors/basic-event-filters.js
@@ -6,7 +6,7 @@ import startOfDay from "date-fns/start_of_day";
 import type { Event } from "../data/event";
 import type { DateRange, Time } from "../data/date-time";
 
-const locale = "en-GB";
+import locale from "../data/locale";
 
 export const buildDateFilter = (date: string) => (event: Event) =>
   areRangesOverlapping(

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -5,7 +5,7 @@ import { buildEventFilter } from "./event-filters";
 import type { State } from "../reducers";
 import type { Asset, Event, FeaturedEvents, EventDays } from "../data/event";
 
-const locale = "en-GB";
+import locale from "../data/locale";
 
 export const groupEventsByStartTime = (events: Event[]): EventDays => {
   const sections = events


### PR DESCRIPTION
As there is no validation in contentful if the `startTime` is after the `endTime` then we should switch them around as to not break elements in the UI.

I have also moved the locale into a separate module. (Probably should have done this in a separate PR but thought some housekeeping wouldn't go amiss).

Fixes: #73

## Pre-flight check-list
* [x] Documentation (N/A)
* [x] Unit tests

## Pre-merge check-list

* [ ] Tester approved

## TestPlan
- [ ] Create/change an event in contentful with the start date before the end date.
- [ ] App does not break and start and end date should be switched.
