### PR TITLE
Re-using category labels

### DIFF
--- a/src/components/CategoriesPills.js
+++ b/src/components/CategoriesPills.js
@@ -3,42 +3,21 @@ import React from "react";
 import { View, StyleSheet, ScrollView, PixelRatio } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
 import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
+import CategoryPill from "./CategoryPill";
 import Text from "./Text";
 import text from "../constants/text";
-import eventCategories from "../constants/event-categories";
-import locale from "../data/locale";
 
 import {
-  blackColor,
-  whiteColor,
   darkBlueGreyTwoColor,
   eucalyptusGreenColor,
   blackZeroColor,
   blackThirtyColor
 } from "../constants/colors";
 
-const categoryStyleColor = (category: string) => {
-  const categoryData = eventCategories[locale][category];
-  return { color: categoryData.contrast ? blackColor : whiteColor };
-};
-
-const categoryStyleBackgroundColor = (category: string) => {
-  const categoryData = eventCategories[locale][category];
-  return { backgroundColor: categoryData.color };
-};
-
 type Props = {
   selectedCategories: Set<string>,
   style?: StyleObj
 };
-
-const CategoryPill = ({ name }: { name: string }) => (
-  <View style={[styles.categoryPill, categoryStyleBackgroundColor(name)]}>
-    <Text type="h3" style={[styles.categoryPillText, categoryStyleColor(name)]}>
-      {name}
-    </Text>
-  </View>
-);
 
 class CategoriesPills extends React.PureComponent<Props> {
   static defaultProps = {
@@ -81,7 +60,11 @@ class CategoriesPills extends React.PureComponent<Props> {
               onContentSizeChange={this.scrollToLastPill}
             >
               {Array.from(selectedCategories).map(name => (
-                <CategoryPill key={name} name={name} />
+                <CategoryPill
+                  key={name}
+                  name={name}
+                  style={styles.categoryPill}
+                />
               ))}
             </ScrollView>
             <LinearGradient
@@ -106,11 +89,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     flexDirection: "row"
   },
-  zeroSelected: {
-    color: eucalyptusGreenColor,
-    paddingTop: 4,
-    paddingLeft: 8
-  },
   categoryPill: {
     flex: 1,
     justifyContent: "center",
@@ -118,13 +96,12 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 8,
     marginLeft: 6,
-    paddingLeft: 5,
-    paddingRight: 5,
     marginRight: 2
   },
-  categoryPillText: {
-    color: whiteColor,
-    paddingTop: 4
+  zeroSelected: {
+    color: eucalyptusGreenColor,
+    paddingTop: 4,
+    paddingLeft: 8
   },
   scrollView: {
     width: "100%"

--- a/src/components/CategoriesPills.test.js
+++ b/src/components/CategoriesPills.test.js
@@ -1,8 +1,6 @@
 // @flow
 import React from "react";
 import { shallow } from "enzyme";
-import * as colors from "../constants/colors";
-
 import CategoriesPills from "./CategoriesPills";
 
 const render = props => shallow(<CategoriesPills {...props} />);
@@ -25,19 +23,6 @@ describe("CategoriesPills Component", () => {
     const categoriesPills = output.find("ScrollView").children();
 
     expect(categoriesPills.length).toEqual(selectedCategories.size);
-  });
-
-  it("renders pills with the category color", () => {
-    const expectedColor = colors.brightLightBlueColor;
-    const selectedCategories: Set<string> = new Set(["Community"]);
-    const output = render({ selectedCategories });
-
-    const pillCustomStyles = output
-      .find("CategoryPill")
-      .dive()
-      .prop("style")[1];
-
-    expect(pillCustomStyles.backgroundColor).toEqual(expectedColor);
   });
 
   describe("#scrollToLastPill", () => {

--- a/src/components/CategoryPill.js
+++ b/src/components/CategoryPill.js
@@ -1,0 +1,50 @@
+// @flow
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import type { StyleObj } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
+import Text from "./Text";
+import eventCategories from "../constants/event-categories";
+import locale from "../data/locale";
+import { blackColor, whiteColor } from "../constants/colors";
+
+const categoryStyleColor = (category: string) => {
+  const categoryData = eventCategories[locale][category];
+  return { color: categoryData.contrast ? blackColor : whiteColor };
+};
+
+const categoryStyleBackgroundColor = (category: string) => {
+  const categoryData = eventCategories[locale][category];
+  return { backgroundColor: categoryData.color };
+};
+
+type Props = {
+  name: string,
+  style?: StyleObj
+};
+
+const CategoryPill = ({ name, style }: Props) => (
+  <View
+    style={[styles.categoryPill, categoryStyleBackgroundColor(name), style]}
+  >
+    <Text type="h3" style={[styles.categoryPillText, categoryStyleColor(name)]}>
+      {name}
+    </Text>
+  </View>
+);
+
+CategoryPill.defaultProps = {
+  style: {}
+};
+
+const styles = StyleSheet.create({
+  categoryPill: {
+    paddingLeft: 5,
+    paddingRight: 5
+  },
+  categoryPillText: {
+    color: whiteColor,
+    paddingTop: 3
+  }
+});
+
+export default CategoryPill;

--- a/src/components/CategoryPill.test.js
+++ b/src/components/CategoryPill.test.js
@@ -1,0 +1,23 @@
+// @flow
+import React from "react";
+import { shallow } from "enzyme";
+import * as colors from "../constants/colors";
+
+import CategoryPill from "./CategoryPill";
+
+const render = props => shallow(<CategoryPill {...props} />);
+
+describe("CategoryPill Component", () => {
+  it("renders correctly", () => {
+    expect(render({ name: "Music" })).toMatchSnapshot();
+  });
+
+  it("renders pills with the category color", () => {
+    const expectedColor = colors.brightLightBlueColor;
+    const output = render({ name: "Community" });
+
+    const pillCustomStyles = output.prop("style")[1];
+
+    expect(pillCustomStyles.backgroundColor).toEqual(expectedColor);
+  });
+});

--- a/src/components/__snapshots__/CategoryPill.test.js.snap
+++ b/src/components/__snapshots__/CategoryPill.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CategoryPill Component renders correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "paddingLeft": 5,
+        "paddingRight": 5,
+      },
+      Object {
+        "backgroundColor": "#5770d1",
+      },
+      Object {},
+    ]
+  }
+>
+  <Text
+    allowFontScaling={true}
+    markdown={false}
+    style={
+      Array [
+        Object {
+          "color": "#ffffff",
+          "paddingTop": 3,
+        },
+        Object {
+          "color": "#ffffff",
+        },
+      ]
+    }
+    type="h3"
+  >
+    Music
+  </Text>
+</View>
+`;

--- a/src/screens/EventDetailsScreen/EventOverview.js
+++ b/src/screens/EventDetailsScreen/EventOverview.js
@@ -4,7 +4,7 @@ import { Image, View, StyleSheet } from "react-native";
 import formatDate from "date-fns/format";
 import isSameDay from "date-fns/is_same_day";
 import IconItem from "./IconItem";
-import CategoryLabel from "./CategoryLabel";
+import CategoryPill from "../../components/CategoryPill";
 import Text from "../../components/Text";
 import ContentPadding from "../../components/ContentPadding";
 import { whiteColor, lightNavyBlueColor } from "../../constants/colors";
@@ -41,9 +41,13 @@ const EventOverview = ({ event }: Props) => {
   return (
     <ContentPadding style={styles.content}>
       <Text type="h1">{event.fields.name[locale]}</Text>
-      <View style={styles.categoryLabelContainer}>
+      <View style={styles.categoryPillContainer}>
         {event.fields.eventCategories[locale].map(categoryName => (
-          <CategoryLabel key={categoryName} categoryName={categoryName} />
+          <CategoryPill
+            key={categoryName}
+            name={categoryName}
+            style={styles.categoryPill}
+          />
         ))}
       </View>
       <IconItem icon={<Image source={dateIcon} />} style={styles.iconItem}>
@@ -98,11 +102,15 @@ const styles = StyleSheet.create({
     paddingVertical: 15,
     backgroundColor: whiteColor
   },
-  categoryLabelContainer: {
+  categoryPillContainer: {
     marginTop: 16,
     marginBottom: 20,
     flexDirection: "row",
     flexWrap: "wrap"
+  },
+  categoryPill: {
+    marginBottom: 8,
+    marginRight: 8
   },
   iconItem: {
     marginBottom: 20

--- a/src/screens/EventDetailsScreen/__snapshots__/EventOverview.test.js.snap
+++ b/src/screens/EventDetailsScreen/__snapshots__/EventOverview.test.js.snap
@@ -27,21 +27,45 @@ exports[`renders correctly 1`] = `
       }
     }
   >
-    <CategoryLabel
-      categoryName="Community"
+    <CategoryPill
       key="Community"
+      name="Community"
+      style={
+        Object {
+          "marginBottom": 8,
+          "marginRight": 8,
+        }
+      }
     />
-    <CategoryLabel
-      categoryName="Social and Networking"
+    <CategoryPill
       key="Social and Networking"
+      name="Social and Networking"
+      style={
+        Object {
+          "marginBottom": 8,
+          "marginRight": 8,
+        }
+      }
     />
-    <CategoryLabel
-      categoryName="Sports and Activities"
+    <CategoryPill
       key="Sports and Activities"
+      name="Sports and Activities"
+      style={
+        Object {
+          "marginBottom": 8,
+          "marginRight": 8,
+        }
+      }
     />
-    <CategoryLabel
-      categoryName="Music"
+    <CategoryPill
       key="Music"
+      name="Music"
+      style={
+        Object {
+          "marginBottom": 8,
+          "marginRight": 8,
+        }
+      }
     />
   </View>
   <IconItem


### PR DESCRIPTION
## Pre-flight check-list

Before raising a pull request

* [x] ~~Documentation~~
* [x] ~~Unit tests~~ (Already covered by snapshot tests)

## Pre-merge check-list

* [x] Link to Trello ticket/GitHub issue (If applicable)
https://trello.com/c/iW3T4PWb/128-ui-events-listing-view-individual-event-details

## Notes

I would suggest a smaller font size for these actually as long categories like "Cabaret and Variety" wrap the next label to a new line:
![image](https://user-images.githubusercontent.com/57560/38824832-71314d38-41a2-11e8-8a67-7d7275e6fe1d.png)

