### PR TITLE
Saved events screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import LinearGradient from "react-native-linear-gradient";
 import EventsScreen from "./screens/EventsScreen";
 import EventDetailsScreen from "./screens/EventDetailsScreen";
 import FeaturedEventListScreen from "./screens/FeaturedEventListScreen";
+import SavedEventListScreen from "./screens/SavedEventListScreen";
 import HomeScreen from "./screens/HomeScreen";
 import FilterModal from "./screens/FilterModal";
 import CategoriesFilterScreen from "./screens/CategoriesFilterScreen";
@@ -124,7 +125,7 @@ const ParadeStack = StackNavigator(
 
 const SavedStack = StackNavigator(
   {
-    [SAVED]: { screen: withShadow(() => <View />) }
+    [SAVED]: { screen: withShadow(SavedEventListScreen) }
   },
   {
     initialRouteName: SAVED,

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,6 +1,7 @@
 export const EVENT_DETAILS = "EVENT_DETAILS";
 export const EVENT_LIST = "EVENT_LIST";
 export const FEATURED_EVENT_LIST = "FEATURED_EVENT_LIST";
+export const SAVED_EVENT_LIST = "SAVED_EVENT_LIST";
 export const HOME = "HOME";
 export const EVENT_CATEGORIES_FILTER = "EVENT_CATEGORIES_FILTER";
 export const PARADE = "PARADE";

--- a/src/constants/text.js
+++ b/src/constants/text.js
@@ -55,6 +55,7 @@ export default {
   eventDetailsContactEmailBody: "Dear event organiser,",
   collapsibleShowMore: "Show more",
   collapsibleShowLess: "Show less",
+  savedEventsTitle: "Saved Events",
   supportUsTitle: "Support us",
   supportUsAsIndividual: "As an individual",
   supportUsAsBusiness: "As a business",

--- a/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventsScreen Component renders correctly 1`] = `
+<Component
+  style={
+    Object {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
+  }
+>
+  <Connect(FilterHeader)
+    onFilterButtonPress={[Function]}
+    onFilterCategoriesPress={[Function]}
+    selectedCategories={Set {}}
+  />
+  <EventList
+    addSavedEvent={[Function]}
+    events={Array []}
+    getAssetUrl={[Function]}
+    locale="en-GB"
+    onPress={[Function]}
+    onRefresh={[Function]}
+    refreshing={false}
+    removeSavedEvent={[Function]}
+    savedEvents={Set {}}
+  />
+</Component>
+`;

--- a/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
@@ -9,11 +9,35 @@ exports[`EventsScreen Component renders correctly 1`] = `
     }
   }
 >
-  <Connect(FilterHeader)
-    onFilterButtonPress={[Function]}
-    onFilterCategoriesPress={[Function]}
-    selectedCategories={Set {}}
-  />
+  <Header
+    backgroundColor="#2d2f7f"
+  >
+    <ContentPadding
+      padding={Object {}}
+      style={
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "height": 48,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        color="blackColor"
+        markdown={false}
+        markdownStyle={Object {}}
+        style={
+          Object {
+            "color": "#ffffff",
+          }
+        }
+        type="h2"
+      >
+        Saved Events
+      </Text>
+    </ContentPadding>
+  </Header>
   <EventList
     addSavedEvent={[Function]}
     events={Array []}

--- a/src/screens/SavedEventListScreen/component.js
+++ b/src/screens/SavedEventListScreen/component.js
@@ -6,6 +6,7 @@ import type { SavedEvents, EventDays } from "../../data/event";
 import type { LocalizedFieldRef } from "../../data/localized-field-ref";
 import EventList from "../../components/EventList";
 import Header from "../../components/Header";
+import text from "../../constants/text";
 import ContentPadding from "../../components/ContentPadding";
 import IconButton from "../../components/IconButton";
 import Text from "../../components/Text";
@@ -64,7 +65,7 @@ class SavedEventListScreen extends PureComponent<Props> {
         <Header backgroundColor={lightNavyBlueColor}>
           <ContentPadding style={styles.headerContent}>
             <Text type="h2" style={styles.headerTitle}>
-              Saveeeeed events
+              {text.savedEventsTitle}
             </Text>
           </ContentPadding>
         </Header>

--- a/src/screens/SavedEventListScreen/component.js
+++ b/src/screens/SavedEventListScreen/component.js
@@ -1,0 +1,111 @@
+// @flow
+import React, { PureComponent } from "react";
+import { StyleSheet, View } from "react-native";
+import type { NavigationScreenProp, NavigationState } from "react-navigation";
+import type { SavedEvents, EventDays } from "../../data/event";
+import type { LocalizedFieldRef } from "../../data/localized-field-ref";
+import EventList from "../../components/EventList";
+import Header from "../../components/Header";
+import ContentPadding from "../../components/ContentPadding";
+import IconButton from "../../components/IconButton";
+import Text from "../../components/Text";
+import {
+  bgColor,
+  whiteColor,
+  lightNavyBlueColor
+} from "../../constants/colors";
+import {
+  EVENT_DETAILS,
+  EVENT_CATEGORIES_FILTER,
+  FILTER_MODAL
+} from "../../constants/routes";
+import locale from "../../data/locale";
+import chevronLeftWhite from "../../../assets/images/chevron-left-white.png";
+
+export type Props = {
+  navigation: NavigationScreenProp<NavigationState>,
+  events: EventDays,
+  savedEvents: SavedEvents,
+  addSavedEvent: string => void,
+  removeSavedEvent: string => void,
+  loading: boolean,
+  refreshing: boolean,
+  updateEvents: () => Promise<void>,
+  getAssetUrl: LocalizedFieldRef => string,
+  selectedCategories: Set<string>
+};
+
+class SavedEventListScreen extends PureComponent<Props> {
+  static navigationOptions = {
+    header: null
+  };
+
+  handleFilterCategoriesPress = () => {
+    this.props.navigation.navigate(EVENT_CATEGORIES_FILTER);
+  };
+
+  handleFilterButtonPress = () => {
+    this.props.navigation.navigate(FILTER_MODAL);
+  };
+
+  render() {
+    const {
+      navigation,
+      updateEvents,
+      events,
+      savedEvents,
+      addSavedEvent,
+      removeSavedEvent,
+      refreshing,
+      getAssetUrl
+    } = this.props;
+    return (
+      <View style={styles.container}>
+        <Header backgroundColor={lightNavyBlueColor}>
+          <ContentPadding style={styles.headerContent}>
+            <Text type="h2" style={styles.headerTitle}>
+              Saveeeeed events
+            </Text>
+          </ContentPadding>
+        </Header>
+        {this.props.loading ? (
+          <Text>Loading...</Text>
+        ) : (
+          <EventList
+            locale={locale}
+            events={events}
+            savedEvents={savedEvents}
+            addSavedEvent={addSavedEvent}
+            removeSavedEvent={removeSavedEvent}
+            refreshing={refreshing}
+            onRefresh={() => {
+              updateEvents();
+            }}
+            onPress={(eventId: string) => {
+              navigation.navigate(EVENT_DETAILS, { eventId });
+            }}
+            getAssetUrl={getAssetUrl}
+          />
+        )}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: bgColor
+  },
+  headerContent: {
+    height: 48,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  headerTitle: {
+    color: whiteColor
+  }
+});
+
+export default SavedEventListScreen;

--- a/src/screens/SavedEventListScreen/component.test.js
+++ b/src/screens/SavedEventListScreen/component.test.js
@@ -50,7 +50,7 @@ describe("EventsScreen Component", () => {
       />
     );
 
-    const loadingText = output.find("Text");
+    const loadingText = output.find("Text").last();
 
     expect(loadingText.children().text()).toEqual("Loading...");
   });
@@ -78,55 +78,5 @@ describe("EventsScreen Component", () => {
       .onRefresh();
 
     expect(updateEvents).toHaveBeenCalled();
-  });
-
-  describe("navigation", () => {
-    const navigationSpy = jest.fn();
-    const nav: NavigationScreenProp<NavigationState> = ({
-      navigate: navigationSpy
-    }: any);
-
-    const output = shallow(
-      <Component
-        navigation={nav}
-        events={[]}
-        loading={false}
-        refreshing={false}
-        updateEvents={() => Promise.resolve()}
-        getAssetUrl={() => ""}
-        selectedCategories={new Set()}
-        addSavedEvent={() => {}}
-        removeSavedEvent={() => {}}
-        savedEvents={new Set()}
-      />
-    );
-
-    beforeEach(() => {
-      navigationSpy.mockClear();
-    });
-
-    it("opens the categories filter", () => {
-      output
-        .find(FilterHeader)
-        .props()
-        .onFilterCategoriesPress();
-      expect(navigationSpy).toBeCalledWith(EVENT_CATEGORIES_FILTER);
-    });
-
-    it("opens the categories filter", () => {
-      output
-        .find(FilterHeader)
-        .props()
-        .onFilterButtonPress();
-      expect(navigationSpy).toBeCalledWith(FILTER_MODAL);
-    });
-
-    it("opens an event", () => {
-      output
-        .find(EventList)
-        .props()
-        .onPress(1);
-      expect(navigationSpy).toBeCalledWith(EVENT_DETAILS, { eventId: 1 });
-    });
   });
 });

--- a/src/screens/SavedEventListScreen/component.test.js
+++ b/src/screens/SavedEventListScreen/component.test.js
@@ -1,0 +1,132 @@
+// @flow
+import React from "react";
+import type { NavigationScreenProp, NavigationState } from "react-navigation";
+import { shallow } from "enzyme";
+import Component from "./component";
+import FilterHeader from "../../components/ConnectedFilterHeader";
+import EventList from "../../components/EventList";
+import {
+  EVENT_CATEGORIES_FILTER,
+  FILTER_MODAL,
+  EVENT_DETAILS
+} from "../../constants/routes";
+
+const navigation: NavigationScreenProp<NavigationState> = ({
+  navigate: () => {}
+}: any);
+
+describe("EventsScreen Component", () => {
+  it("renders correctly", () => {
+    const output = shallow(
+      <Component
+        navigation={navigation}
+        events={[]}
+        loading={false}
+        refreshing={false}
+        updateEvents={() => Promise.resolve()}
+        getAssetUrl={() => ""}
+        selectedCategories={new Set()}
+        addSavedEvent={() => {}}
+        removeSavedEvent={() => {}}
+        savedEvents={new Set()}
+      />
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it("renders loading indicator when loading", () => {
+    const output = shallow(
+      <Component
+        navigation={navigation}
+        events={[]}
+        loading
+        refreshing={false}
+        updateEvents={() => Promise.resolve()}
+        getAssetUrl={() => ""}
+        selectedCategories={new Set()}
+        addSavedEvent={() => {}}
+        removeSavedEvent={() => {}}
+        savedEvents={new Set()}
+      />
+    );
+
+    const loadingText = output.find("Text");
+
+    expect(loadingText.children().text()).toEqual("Loading...");
+  });
+
+  it("updates events on refresh", () => {
+    const updateEvents = jest.fn();
+    const output = shallow(
+      <Component
+        navigation={navigation}
+        events={[]}
+        loading={false}
+        refreshing={false}
+        updateEvents={updateEvents}
+        getAssetUrl={() => ""}
+        selectedCategories={new Set()}
+        addSavedEvent={() => {}}
+        removeSavedEvent={() => {}}
+        savedEvents={new Set()}
+      />
+    );
+
+    output
+      .find(EventList)
+      .props()
+      .onRefresh();
+
+    expect(updateEvents).toHaveBeenCalled();
+  });
+
+  describe("navigation", () => {
+    const navigationSpy = jest.fn();
+    const nav: NavigationScreenProp<NavigationState> = ({
+      navigate: navigationSpy
+    }: any);
+
+    const output = shallow(
+      <Component
+        navigation={nav}
+        events={[]}
+        loading={false}
+        refreshing={false}
+        updateEvents={() => Promise.resolve()}
+        getAssetUrl={() => ""}
+        selectedCategories={new Set()}
+        addSavedEvent={() => {}}
+        removeSavedEvent={() => {}}
+        savedEvents={new Set()}
+      />
+    );
+
+    beforeEach(() => {
+      navigationSpy.mockClear();
+    });
+
+    it("opens the categories filter", () => {
+      output
+        .find(FilterHeader)
+        .props()
+        .onFilterCategoriesPress();
+      expect(navigationSpy).toBeCalledWith(EVENT_CATEGORIES_FILTER);
+    });
+
+    it("opens the categories filter", () => {
+      output
+        .find(FilterHeader)
+        .props()
+        .onFilterButtonPress();
+      expect(navigationSpy).toBeCalledWith(FILTER_MODAL);
+    });
+
+    it("opens an event", () => {
+      output
+        .find(EventList)
+        .props()
+        .onPress(1);
+      expect(navigationSpy).toBeCalledWith(EVENT_DETAILS, { eventId: 1 });
+    });
+  });
+});

--- a/src/screens/SavedEventListScreen/index.js
+++ b/src/screens/SavedEventListScreen/index.js
@@ -9,7 +9,7 @@ import {
   groupEventsByStartTime,
   selectEventsLoading,
   selectEventsRefreshing,
-  selectFilteredEvents,
+  selectSavedEvents,
   selectAssetById
 } from "../../selectors/events";
 import type { Props as ComponentProps } from "./component";
@@ -22,7 +22,7 @@ type OwnProps = {
 type Props = ComponentProps & OwnProps;
 
 const mapStateToProps = state => ({
-  events: groupEventsByStartTime(selectFilteredEvents(state)),
+  events: groupEventsByStartTime(selectSavedEvents(state)),
   savedEvents: state.savedEvents,
   loading: selectEventsLoading(state),
   refreshing: selectEventsRefreshing(state),

--- a/src/screens/SavedEventListScreen/index.js
+++ b/src/screens/SavedEventListScreen/index.js
@@ -1,0 +1,44 @@
+// @flow
+import { connect } from "react-redux";
+import type { Connector } from "react-redux";
+import type { NavigationScreenProp, NavigationState } from "react-navigation";
+import getAssetUrl from "../../data/get-asset-url";
+import { updateEvents } from "../../actions/events";
+import { addSavedEvent, removeSavedEvent } from "../../actions/saved-events";
+import {
+  groupEventsByStartTime,
+  selectEventsLoading,
+  selectEventsRefreshing,
+  selectFilteredEvents,
+  selectAssetById
+} from "../../selectors/events";
+import type { Props as ComponentProps } from "./component";
+import Component from "./component";
+
+type OwnProps = {
+  navigation: NavigationScreenProp<NavigationState>
+};
+
+type Props = ComponentProps & OwnProps;
+
+const mapStateToProps = state => ({
+  events: groupEventsByStartTime(selectFilteredEvents(state)),
+  savedEvents: state.savedEvents,
+  loading: selectEventsLoading(state),
+  refreshing: selectEventsRefreshing(state),
+  getAssetUrl: getAssetUrl(id => selectAssetById(state, id)),
+  selectedCategories: state.eventFilters.selectedFilters.categories
+});
+
+const mapDispatchToProps = {
+  updateEvents,
+  addSavedEvent,
+  removeSavedEvent
+};
+
+const connector: Connector<OwnProps, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
+export default connector(Component);

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -161,3 +161,9 @@ export const selectFeaturedEventsByTitle = (state: State, title: string) => {
     selectEventById(state, e.sys.id)
   ): any): Event[]);
 };
+
+export const selectSavedEvents = (state: State) => {
+  const events = getEventsState(state).entries;
+  const savedEvents = state.savedEvents;
+  return events.filter(event => savedEvents.has(event.sys.id));
+};

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -11,7 +11,8 @@ import {
   selectAssetById,
   selectFilteredEvents,
   selectFeaturedEventsByTitle,
-  uniqueEvents
+  uniqueEvents,
+  selectSavedEvents
 } from "./events";
 import { buildEventFilter } from "./event-filters";
 
@@ -770,4 +771,93 @@ describe("selectFeaturedEventsByTitle", () => {
 
 afterEach(() => {
   buildEventFilter.mockReset();
+});
+
+describe("mapSavedIDsToEvents", () => {
+  it("returns empty array when no savedEvents", () => {
+    const state = {
+      events: {
+        entries: [
+          {
+            fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+            sys: { id: "1", contentType: { sys: { id: "event" } } }
+          },
+          {
+            fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+            sys: { id: "2", contentType: { sys: { id: "event" } } }
+          }
+        ]
+      },
+      savedEvents: new Set([])
+    };
+
+    const expected = [];
+    const actual = selectSavedEvents(state);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("returns array of saved events", () => {
+    const state = {
+      events: {
+        entries: [
+          {
+            fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+            sys: { id: "1", contentType: { sys: { id: "event" } } }
+          },
+          {
+            fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+            sys: { id: "2", contentType: { sys: { id: "event" } } }
+          }
+        ]
+      },
+      savedEvents: new Set(["1"])
+    };
+
+    const expected = [
+      {
+        fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+        sys: { id: "1", contentType: { sys: { id: "event" } } }
+      }
+    ];
+    const actual = selectSavedEvents(state);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("returns array of saved events", () => {
+    const state = {
+      events: {
+        entries: [
+          {
+            fields: { startTime: { "en-GB": "2018-08-02T00:00:00" } },
+            sys: { id: "1", contentType: { sys: { id: "event" } } }
+          },
+          {
+            fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+            sys: { id: "2", contentType: { sys: { id: "event" } } }
+          },
+          {
+            fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+            sys: { id: "3", contentType: { sys: { id: "event" } } }
+          }
+        ]
+      },
+      savedEvents: new Set(["3", "2"])
+    };
+
+    const expected = [
+      {
+        fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+        sys: { id: "2", contentType: { sys: { id: "event" } } }
+      },
+      {
+        fields: { startTime: { "en-GB": "2018-08-01T00:00:00" } },
+        sys: { id: "3", contentType: { sys: { id: "event" } } }
+      }
+    ];
+    const actual = selectSavedEvents(state);
+
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## Pre-flight check-list

### In this PR
- Saved events icon goes to an event listing type screen
- Saved events page only shows saved events

### Future PRs
- No saved events screen
- Need to confirm what is meant to happen when you select an event, then press the back button. which screen should you see?

Before raising a pull request

* [?] Documentation
* [x] Unit tests

## Pre-merge check-list

* [x] Link to Trello ticket/GitHub issue (If applicable) https://trello.com/c/CPa5xWwS
* [x] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
