### PR TITLE
iTunes Connect query without app version is too vague

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode androidVersionCode
-        versionName "1.0.6"
+        versionName "1.0.7"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/ios/PrideLondonApp/Info.plist
+++ b/ios/PrideLondonApp/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/PrideLondonAppTests/Info.plist
+++ b/ios/PrideLondonAppTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -90,8 +90,9 @@ platform :ios do
   lane :release do |options|
     # Testflight builds can be promoted to production so
     # we have to do another build with appstore signing
+    app_version = get_version_number(xcodeproj: "PrideLondonApp.xcodeproj")
     increment_build_number(
-      build_number: latest_testflight_build_number + 1,
+      build_number: latest_testflight_build_number(version: app_version, live:false) + 1,
       xcodeproj: "PrideLondonApp.xcodeproj"
     )
     build(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pride-london-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "private": true,
   "scripts": {


### PR DESCRIPTION
We started getting an error when trying to retrieve the current build version in iTunes Connect.

https://circleci.com/gh/redbadger/pride-london-app/3571

We use this to know what a valid build number would be before starting a release build. This has worked fine up until now but a recent iTunes issue caused build `91` of `1.0.5` to not be accepted. To get around that initial issue we increased our app version to `1.0.6` and build `91` of this version was submitted succesfully.

But as of today iTunes now shows the failed `91` build of `1.0.5` so when we query for the latest build number there are two versions with build number `91` leading to iTunes not knowing which version we mean.

`You have to specify a new version number, as there are multiple to choose from`

The fix is to start passing the app version to this call, we get the current version from the Xcode project.