### PR TITLE
Use CI build number for iOS release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,8 @@ jobs:
       - run:
             command: |
                 bundle exec fastlane release \
-                submit:true
+                submit:true \
+                ci_build_num:$CIRCLE_BUILD_NUM
 
   e2e-ios:
     <<: *job-defaults-macos

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -88,13 +88,8 @@ platform :ios do
 
   desc "Build and Deploy a release to iTunes Connect"
   lane :release do |options|
-    # Testflight builds can be promoted to production so
-    # we have to do another build with appstore signing
-    app_version = get_version_number(xcodeproj: "PrideLondonApp.xcodeproj")
-    increment_build_number(
-      build_number: latest_testflight_build_number(version: app_version, live:false) + 1,
-      xcodeproj: "PrideLondonApp.xcodeproj"
-    )
+    ensure_git_branch(branch: "master")
+    increment_build_number(build_number:options[:ci_build_num])
     build(
       match_type: "appstore",
       export_method: "app-store",


### PR DESCRIPTION
Up until now we have made use of Fastlane functionality that allows you to retrieve the latest build number from iTunes Connect. This is to ensure that you never submit a build that already exists as it will be instantly rejected without notification. Recently this has become very flaky.

Instead we will use the same method we have for all other builds and take the build number provided by CI. This will always be unique and incremental.