### PR TITLE
Fix button overlap on support us screen

### DIFF
--- a/src/components/ButtonWithShapes.js
+++ b/src/components/ButtonWithShapes.js
@@ -108,9 +108,11 @@ class SupportUsButton extends React.PureComponent<Props> {
 
 const styles = StyleSheet.create({
   button: {
+    // Can't use `minHeight` because it has a weird behaviour. The
+    // button will have the correct size but the sibling elements
+    // will layout according to the buttons (smaller) `height`.
+    height: Math.max(100, 100 * PixelRatio.getFontScale()),
     justifyContent: "center",
-    height: 100 * PixelRatio.getFontScale(),
-    minHeight: 100,
     borderRadius: 5,
     overflow: "hidden",
 

--- a/src/components/Text.test.js
+++ b/src/components/Text.test.js
@@ -29,7 +29,6 @@ it("does not render markdown images", () => {
     <Text markdown>![Test](https://placehold.it/320x320.png)</Text>
   );
   const markdown = output.find(Markdown).shallow();
-  console.log(markdown);
   expect(markdown).toMatchSnapshot();
 });
 

--- a/src/components/__snapshots__/ButtonWithShapes.test.js.snap
+++ b/src/components/__snapshots__/ButtonWithShapes.test.js.snap
@@ -18,7 +18,6 @@ exports[`picks different icon for external links 1`] = `
         "elevation": 3,
         "height": 200,
         "justifyContent": "center",
-        "minHeight": 100,
         "overflow": "hidden",
         "shadowColor": "rgba(0, 0, 0, 0.2)",
         "shadowOffset": Object {
@@ -124,7 +123,6 @@ exports[`picks different icon for external links with contrast color 1`] = `
         "elevation": 3,
         "height": 200,
         "justifyContent": "center",
-        "minHeight": 100,
         "overflow": "hidden",
         "shadowColor": "rgba(0, 0, 0, 0.2)",
         "shadowOffset": Object {
@@ -230,7 +228,6 @@ exports[`renders correctly 1`] = `
         "elevation": 3,
         "height": 200,
         "justifyContent": "center",
-        "minHeight": 100,
         "overflow": "hidden",
         "shadowColor": "rgba(0, 0, 0, 0.2)",
         "shadowOffset": Object {


### PR DESCRIPTION
Fixes #161

Thanks for the tip with the iPhone X @kristofhamilton. I was able to reproduce this in the simulator when using a smaller font size as the default.

This fixes the issue on the simulator. But to be sure that it fixes the actual reported issue, it would be great if someone could test this.

## Pre-merge check-list

* [x] Link to Trello ticket/GitHub issue (If applicable)
* ~Any risky areas identified~
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
