### PR TITLE
Fix donate button double tap issue

### DIFF
--- a/src/screens/DonateScreen/__snapshots__/index.test.js.snap
+++ b/src/screens/DonateScreen/__snapshots__/index.test.js.snap
@@ -26,7 +26,9 @@ exports[`renders correctly 1`] = `
       }
     }
   >
-    <ScrollView>
+    <ScrollView
+      keyboardShouldPersistTaps="always"
+    >
       <Component
         style={
           Object {

--- a/src/screens/DonateScreen/index.js
+++ b/src/screens/DonateScreen/index.js
@@ -95,7 +95,7 @@ class DonateScreen extends React.PureComponent<Props, State> {
   renderContent() {
     const { selectedAmount, otherAmount } = this.state;
     return (
-      <ScrollView ref={this.scrollViewRef}>
+      <ScrollView ref={this.scrollViewRef} keyboardShouldPersistTaps="always">
         <View style={styles.scrollContainer}>
           <ImageHeader image={donateHeader} title={text.donateHeader} />
           <ContentPadding>


### PR DESCRIPTION
Fixes #251 

By default, clicking outside of the keyboard area dismisses the keyboard, but children of the Scroll View component do not receive the tap. This can be altered by adjusting the keyboardShouldPersistTaps prop.

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
