### PR TITLE
BUG - Fix filter for event times

### DIFF
--- a/src/selectors/basic-event-filters.js
+++ b/src/selectors/basic-event-filters.js
@@ -26,9 +26,9 @@ function* range(num, end, step = 1): Array<number> {
   }
 }
 
-const morningHours = Array.from(range(0, 11));
-const afternoonHours = Array.from(range(12, 17));
-const eveningHours = Array.from(range(18, 23));
+const morningHours = Array.from(range(0, 12));
+const afternoonHours = Array.from(range(12, 18));
+const eveningHours = Array.from(range(18, 24));
 
 type TimeFilter = (timeFilter: Time) => (event: Event) => any;
 /* eslint-disable consistent-return */

--- a/src/selectors/basic-event-filters.js
+++ b/src/selectors/basic-event-filters.js
@@ -3,7 +3,6 @@ import areRangesOverlapping from "date-fns/are_ranges_overlapping";
 import endOfDay from "date-fns/end_of_day";
 import getHours from "date-fns/get_hours";
 import startOfDay from "date-fns/start_of_day";
-import isSameDay from "date-fns/is_same_day";
 import { selectEventIsFree } from "./event";
 import areaBoundaries from "../data/areas";
 import type { Event, EventCategoryName } from "../data/event";
@@ -34,14 +33,18 @@ const eveningHours = Array.from(range(18, 23));
 type TimeFilter = (timeFilter: Time) => (event: Event) => any;
 /* eslint-disable consistent-return */
 export const buildTimeFilter: TimeFilter = timeFilter => event => {
-  const { startTime, endTime } = event.fields;
-  const start = getHours(startTime[locale]);
-  const end = getHours(endTime[locale]);
+  const start = getHours(event.fields.startTime[locale]);
+  const end = getHours(event.fields.endTime[locale]);
   switch (timeFilter) {
     case "morning":
       return morningHours.some(x => x === start);
     case "afternoon":
-      return afternoonHours.some(x => x === start || x === end);
+      return afternoonHours.some(x => {
+        const updateEnd = end <= start ? 24 : end;
+        return Array.from(range(start, updateEnd)).some(
+          eventHour => eventHour === x
+        );
+      });
     case "evening":
       return eveningHours.some(x => {
         const updateEnd = end <= start ? 24 : end;

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -83,144 +83,146 @@ describe("buildDateRangeFilter", () => {
 });
 
 describe("buildTimeFilter", () => {
-  it("recognises an event that starts and ends in the morning", () => {
-    const morningEvent = buildEvent({
-      startTime: "2018-08-02T06:00:00",
-      endTime: "2018-08-02T11:00:00"
+  describe("events spanning a single time slot", () => {
+    it("correctly filters an event that starts and ends in the same morning", () => {
+      const morningEvent = buildEvent({
+        startTime: "2018-08-02T06:00:00",
+        endTime: "2018-08-02T11:59:00"
+      });
+
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(morningEvent)).toBe(true);
+      expect(afternoonFilter(morningEvent)).toBe(false);
+      expect(eveningFilter(morningEvent)).toBe(false);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(morningEvent)).toBe(true);
-    expect(afternoonFilter(morningEvent)).toBe(false);
-    expect(eveningFilter(morningEvent)).toBe(false);
+    it("correctly filters an event that starts and ends in the same afternoon", () => {
+      const afternoonEvent = buildEvent({
+        startTime: "2018-08-02T12:00:00",
+        endTime: "2018-08-02T17:59:00"
+      });
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(afternoonEvent)).toBe(false);
+      expect(afternoonFilter(afternoonEvent)).toBe(true);
+      expect(eveningFilter(afternoonEvent)).toBe(false);
+    });
+
+    it("correctly filters an event that starts and ends in the same evening", () => {
+      const eveningEvent = buildEvent({
+        startTime: "2018-08-02T18:00:00",
+        endTime: "2018-08-03T05:59:00"
+      });
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(eveningEvent)).toBe(false);
+      expect(afternoonFilter(eveningEvent)).toBe(false);
+      expect(eveningFilter(eveningEvent)).toBe(true);
+    });
   });
 
-  it("recognises an event that starts and ends in the afternoon", () => {
-    const afternoonEvent = buildEvent({
-      startTime: "2018-08-02T14:00:00",
-      endTime: "2018-08-02T15:00:00"
-    });
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(afternoonEvent)).toBe(false);
-    expect(afternoonFilter(afternoonEvent)).toBe(true);
-    expect(eveningFilter(afternoonEvent)).toBe(false);
-  });
+  describe("events spanning multiple time slots", () => {
+    it("correctly filters an event spanning morning to afternoon", () => {
+      const morningToAfternoon = buildEvent({
+        startTime: "2018-08-02T09:00:00",
+        endTime: "2018-08-02T15:00:00"
+      });
 
-  it("recognises an event that starts and ends in the evening", () => {
-    const eveningEvent = buildEvent({
-      startTime: "2018-08-02T19:00:00",
-      endTime: "2018-08-02T23:00:00"
-    });
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(eveningEvent)).toBe(false);
-    expect(afternoonFilter(eveningEvent)).toBe(false);
-    expect(eveningFilter(eveningEvent)).toBe(true);
-  });
-});
-
-describe("events spanning multiple time slots", () => {
-  it("correctly filters an event spanning morning to afternoon", () => {
-    const morningToAfternoon = buildEvent({
-      startTime: "2018-08-02T09:00:00",
-      endTime: "2018-08-02T15:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(morningToAfternoon)).toBe(true);
+      expect(afternoonFilter(morningToAfternoon)).toBe(true);
+      expect(eveningFilter(morningToAfternoon)).toBe(false);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(morningToAfternoon)).toBe(true);
-    expect(afternoonFilter(morningToAfternoon)).toBe(true);
-    expect(eveningFilter(morningToAfternoon)).toBe(false);
-  });
+    it("correctly filters an event spanning afternoon to evening", () => {
+      const afternoonToEvening = buildEvent({
+        startTime: "2018-08-02T14:00:00",
+        endTime: "2018-08-02T20:00:00"
+      });
 
-  it("correctly filters an event spanning afternoon to evening", () => {
-    const afternoonToEvening = buildEvent({
-      startTime: "2018-08-02T14:00:00",
-      endTime: "2018-08-02T20:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(afternoonToEvening)).toBe(false);
+      expect(afternoonFilter(afternoonToEvening)).toBe(true);
+      expect(eveningFilter(afternoonToEvening)).toBe(true);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(afternoonToEvening)).toBe(false);
-    expect(afternoonFilter(afternoonToEvening)).toBe(true);
-    expect(eveningFilter(afternoonToEvening)).toBe(true);
-  });
+    it("correctly filters an event spanning morning to evening", () => {
+      const morningToEvening = buildEvent({
+        startTime: "2018-08-02T09:00:00",
+        endTime: "2018-08-02T20:00:00"
+      });
 
-  it("correctly filters an event spanning morning to evening", () => {
-    const morningToEvening = buildEvent({
-      startTime: "2018-08-02T09:00:00",
-      endTime: "2018-08-02T20:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(morningToEvening)).toBe(true);
+      expect(afternoonFilter(morningToEvening)).toBe(true);
+      expect(eveningFilter(morningToEvening)).toBe(true);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(morningToEvening)).toBe(true);
-    expect(afternoonFilter(morningToEvening)).toBe(true);
-    expect(eveningFilter(morningToEvening)).toBe(true);
-  });
+    it("correctly filters an event spanning evening to morning", () => {
+      const eveningToMorning = buildEvent({
+        startTime: "2018-08-02T20:00:00",
+        endTime: "2018-08-03T08:00:00"
+      });
 
-  it("correctly filters an event spanning evening to morning", () => {
-    const eveningToMorning = buildEvent({
-      startTime: "2018-08-02T20:00:00",
-      endTime: "2018-08-03T08:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(eveningToMorning)).toBe(true);
+      expect(afternoonFilter(eveningToMorning)).toBe(false);
+      expect(eveningFilter(eveningToMorning)).toBe(true);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(eveningToMorning)).toBe(true);
-    expect(afternoonFilter(eveningToMorning)).toBe(false);
-    expect(eveningFilter(eveningToMorning)).toBe(true);
-  });
+    it("correctly filters an event spanning afternoon to morning", () => {
+      const afternoonToMorning = buildEvent({
+        startTime: "2018-08-02T16:00:00",
+        endTime: "2018-08-03T11:00:00"
+      });
 
-  it("correctly filters an event spanning afternoon to morning", () => {
-    const afternoonToMorning = buildEvent({
-      startTime: "2018-08-02T16:00:00",
-      endTime: "2018-08-03T11:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(afternoonToMorning)).toBe(true);
+      expect(afternoonFilter(afternoonToMorning)).toBe(true);
+      expect(eveningFilter(afternoonToMorning)).toBe(true);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(afternoonToMorning)).toBe(true);
-    expect(afternoonFilter(afternoonToMorning)).toBe(true);
-    expect(eveningFilter(afternoonToMorning)).toBe(true);
-  });
+    it("correctly filters an event spanning evening to afternoon", () => {
+      const eveningToAfternoon = buildEvent({
+        startTime: "2018-08-02T20:00:00",
+        endTime: "2018-08-03T15:00:00"
+      });
 
-  it("correctly filters an event spanning evening to afternoon", () => {
-    const eveningToAfternoon = buildEvent({
-      startTime: "2018-08-02T20:00:00",
-      endTime: "2018-08-03T15:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(eveningToAfternoon)).toBe(true);
+      expect(afternoonFilter(eveningToAfternoon)).toBe(true);
+      expect(eveningFilter(eveningToAfternoon)).toBe(true);
     });
 
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(eveningToAfternoon)).toBe(true);
-    expect(afternoonFilter(eveningToAfternoon)).toBe(true);
-    expect(eveningFilter(eveningToAfternoon)).toBe(true);
-  });
+    it("correctly filters an event spanning morning to morning the following day", () => {
+      const morningToMorning = buildEvent({
+        startTime: "2018-08-02T09:00:00",
+        endTime: "2018-08-03T10:00:00"
+      });
 
-  it("correctly filters an event spanning morning to morning the following day", () => {
-    const morningToMorning = buildEvent({
-      startTime: "2018-08-02T09:00:00",
-      endTime: "2018-08-03T10:00:00"
+      const morningFilter = buildTimeFilter("morning");
+      const afternoonFilter = buildTimeFilter("afternoon");
+      const eveningFilter = buildTimeFilter("evening");
+      expect(morningFilter(morningToMorning)).toBe(true);
+      expect(afternoonFilter(morningToMorning)).toBe(true);
+      expect(eveningFilter(morningToMorning)).toBe(true);
     });
-
-    const morningFilter = buildTimeFilter("morning");
-    const afternoonFilter = buildTimeFilter("afternoon");
-    const eveningFilter = buildTimeFilter("evening");
-    expect(morningFilter(morningToMorning)).toBe(true);
-    expect(afternoonFilter(morningToMorning)).toBe(true);
-    expect(eveningFilter(morningToMorning)).toBe(true);
   });
 });
 

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -134,7 +134,7 @@ describe("buildTimeFilter - an event from 11am until 8pm", () => {
 
   it("checks for bugs in the morning", () => {
     const filter = buildTimeFilter("morning");
-    expect(filter(event)).toBe(false);
+    expect(filter(event)).toBe(true);
   });
 
   it("checks for bugs in the afternoon", () => {

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -6,8 +6,8 @@ import {
   buildPriceFilter,
   buildStringSetFilter,
   buildAreaFilter
-} from './basic-event-filters';
-import type { Event, EventCategoryName } from '../data/event';
+} from "./basic-event-filters";
+import type { Event, EventCategoryName } from "../data/event";
 
 export type BuildEventArguments = {
   startTime?: string,
@@ -22,8 +22,8 @@ export type BuildEventArguments = {
 };
 
 const buildEvent = ({
-  startTime = '2018-08-02T12:00:00',
-  endTime = '2018-08-05T12:00:00',
+  startTime = "2018-08-02T12:00:00",
+  endTime = "2018-08-05T12:00:00",
   eventCategories = [],
   eventPriceLow = 0,
   eventPriceHigh = 12,
@@ -34,198 +34,205 @@ const buildEvent = ({
 }: BuildEventArguments) =>
   (({
     fields: {
-      startTime: { 'en-GB': startTime },
-      endTime: { 'en-GB': endTime },
-      eventCategories: { 'en-GB': eventCategories },
-      eventPriceLow: { 'en-GB': eventPriceLow },
-      eventPriceHigh: { 'en-GB': eventPriceHigh },
-      location: { 'en-GB': location }
+      startTime: { "en-GB": startTime },
+      endTime: { "en-GB": endTime },
+      eventCategories: { "en-GB": eventCategories },
+      eventPriceLow: { "en-GB": eventPriceLow },
+      eventPriceHigh: { "en-GB": eventPriceHigh },
+      location: { "en-GB": location }
     }
   }: any): Event);
 
-describe('buildDateRangeFilter', () => {
+describe("buildDateRangeFilter", () => {
   const event = buildEvent({
-    startTime: '2018-08-02T12:00:00',
-    endTime: '2018-08-05T12:00:00'
+    startTime: "2018-08-02T12:00:00",
+    endTime: "2018-08-05T12:00:00"
   });
 
-  it('returns true when event starts within the given range', () => {
+  it("returns true when event starts within the given range", () => {
     const filter = buildDateRangeFilter({
-      startDate: '2018-08-01',
-      endDate: '2018-08-04'
+      startDate: "2018-08-01",
+      endDate: "2018-08-04"
     });
     expect(filter(event)).toBe(true);
   });
 
-  it('returns true when event ends within the given range', () => {
+  it("returns true when event ends within the given range", () => {
     const filter = buildDateRangeFilter({
-      startDate: '2018-08-04',
-      endDate: '2018-08-10'
+      startDate: "2018-08-04",
+      endDate: "2018-08-10"
     });
     expect(filter(event)).toBe(true);
   });
 
-  it('returns true when event starts before and ends after the given range', () => {
+  it("returns true when event starts before and ends after the given range", () => {
     const filter = buildDateRangeFilter({
-      startDate: '2018-08-01',
-      endDate: '2018-08-10'
+      startDate: "2018-08-01",
+      endDate: "2018-08-10"
     });
     expect(filter(event)).toBe(true);
   });
 
-  it('returns false otherwise', () => {
+  it("returns false otherwise", () => {
     const filter = buildDateRangeFilter({
-      startDate: '2018-07-29',
-      endDate: '2018-08-01'
+      startDate: "2018-07-29",
+      endDate: "2018-08-01"
     });
     expect(filter(event)).toBe(false);
   });
 });
 
-describe('buildTimeFilter', () => {
-  // const event = buildEvent({
-  //   startTime: '2018-08-02T08:00:00',
-  //   endTime: '2018-08-02T15:00:00'
-  // });
-
-  it('recognises an event that starts and ends in the morning', () => {
+describe("buildTimeFilter", () => {
+  it("recognises an event that starts and ends in the morning", () => {
     const morningEvent = buildEvent({
-      startTime: '2018-08-02T06:00:00',
-      endTime: '2018-08-02T11:00:00'
+      startTime: "2018-08-02T06:00:00",
+      endTime: "2018-08-02T11:00:00"
     });
 
-    const filter = buildTimeFilter('morning');
-    expect(filter(morningEvent)).toBe(true);
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(morningEvent)).toBe(true);
+    expect(afternoonFilter(morningEvent)).toBe(false);
+    expect(eveningFilter(morningEvent)).toBe(false);
   });
 
-  it('recognises an event that starts and ends in the afternoon', () => {
+  it("recognises an event that starts and ends in the afternoon", () => {
     const afternoonEvent = buildEvent({
-      startTime: '2018-08-02T14:00:00',
-      endTime: '2018-08-02T15:00:00'
+      startTime: "2018-08-02T14:00:00",
+      endTime: "2018-08-02T15:00:00"
     });
-    const filter = buildTimeFilter('afternoon');
-    expect(filter(afternoonEvent)).toBe(true);
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(afternoonEvent)).toBe(false);
+    expect(afternoonFilter(afternoonEvent)).toBe(true);
+    expect(eveningFilter(afternoonEvent)).toBe(false);
   });
 
-  it('recognises an event that starts and ends in the evening', () => {
+  it("recognises an event that starts and ends in the evening", () => {
     const eveningEvent = buildEvent({
-      startTime: '2018-08-02T19:00:00',
-      endTime: '2018-08-02T23:00:00'
+      startTime: "2018-08-02T19:00:00",
+      endTime: "2018-08-02T23:00:00"
     });
-    const filter = buildTimeFilter('evening');
-    expect(filter(eveningEvent)).toBe(true);
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(eveningEvent)).toBe(false);
+    expect(afternoonFilter(eveningEvent)).toBe(false);
+    expect(eveningFilter(eveningEvent)).toBe(true);
   });
 });
 
-describe('events spanning multiple time slots', () => {
-  it('correctly filters an event spannig morning to afternoon', () => {
+describe("events spanning multiple time slots", () => {
+  it("correctly filters an event spanning morning to afternoon", () => {
     const morningToAfternoon = buildEvent({
-      startTime: '2018-08-02T09:00:00',
-      endTime: '2018-08-02T15:00:00'
+      startTime: "2018-08-02T09:00:00",
+      endTime: "2018-08-02T15:00:00"
     });
 
-    const morningFilter = buildTimeFilter('morning');
-    const afternoonFilter = buildTimeFilter('afternoon');
-    const eveningFilter = buildTimeFilter('evening');
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
     expect(morningFilter(morningToAfternoon)).toBe(true);
     expect(afternoonFilter(morningToAfternoon)).toBe(true);
     expect(eveningFilter(morningToAfternoon)).toBe(false);
   });
 
-  it('correctly filters an event spannig afternoon to evening', () => {
+  it("correctly filters an event spanning afternoon to evening", () => {
     const afternoonToEvening = buildEvent({
-      startTime: '2018-08-02T14:00:00',
-      endTime: '2018-08-02T20:00:00'
+      startTime: "2018-08-02T14:00:00",
+      endTime: "2018-08-02T20:00:00"
     });
 
-    const morningFilter = buildTimeFilter('morning');
-    const afternoonFilter = buildTimeFilter('afternoon');
-    const eveningFilter = buildTimeFilter('evening');
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
     expect(morningFilter(afternoonToEvening)).toBe(false);
     expect(afternoonFilter(afternoonToEvening)).toBe(true);
     expect(eveningFilter(afternoonToEvening)).toBe(true);
   });
 
-  it('correctly filters an event spanning morning to evening', () => {
+  it("correctly filters an event spanning morning to evening", () => {
     const morningToEvening = buildEvent({
-      startTime: '2018-08-02T09:00:00',
-      endTime: '2018-08-03T21:00:00'
+      startTime: "2018-08-02T09:00:00",
+      endTime: "2018-08-02T20:00:00"
     });
 
-    const morningFilter = buildTimeFilter('morning');
-    const afternoonFilter = buildTimeFilter('afternoon');
-    const eveningFilter = buildTimeFilter('evening');
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
     expect(morningFilter(morningToEvening)).toBe(true);
     expect(afternoonFilter(morningToEvening)).toBe(true);
     expect(eveningFilter(morningToEvening)).toBe(true);
   });
 
-  it('correctly filters an event spanning evening to morning', () => {
+  it("correctly filters an event spanning evening to morning", () => {
     const eveningToMorning = buildEvent({
-      startTime: '2018-08-02T20:00:00',
-      endTime: '2018-08-03T08:00:00'
+      startTime: "2018-08-02T20:00:00",
+      endTime: "2018-08-03T08:00:00"
     });
 
-    const morningFilter = buildTimeFilter('morning');
-    const afternoonFilter = buildTimeFilter('afternoon');
-    const eveningFilter = buildTimeFilter('evening');
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
     expect(morningFilter(eveningToMorning)).toBe(true);
     expect(afternoonFilter(eveningToMorning)).toBe(false);
     expect(eveningFilter(eveningToMorning)).toBe(true);
   });
 
-  // it('correctly filters an event spanning afternoon to morning', () => {
-  //   const afternoonToMorning = buildEvent({
-  //     startTime: '2018-08-02T16:00:00',
-  //     endTime: '2018-08-03T11:00:00'
-  //   });
+  it("correctly filters an event spanning afternoon to morning", () => {
+    const afternoonToMorning = buildEvent({
+      startTime: "2018-08-02T16:00:00",
+      endTime: "2018-08-03T11:00:00"
+    });
 
-  //   const morningFilter = buildTimeFilter('morning');
-  //   const afternoonFilter = buildTimeFilter('afternoon');
-  //   const eveningFilter = buildTimeFilter('evening');
-  //   expect(morningFilter(afternoonToMorning)).toBe(true);
-  //   expect(afternoonFilter(afternoonToMorning)).toBe(true);
-  //   expect(eveningFilter(afternoonToMorning)).toBe(true);
-  // });
-
-  // it('correctly filters an event spanning evening to afternoon', () => {
-  //   const eveningToAfternoon = buildEvent({
-  //     startTime: '2018-08-02T20:00:00',
-  //     endTime: '2018-08-03T06:00:00'
-  //   });
-
-  //   const morningFilter = buildTimeFilter('morning');
-  //   const afternoonFilter = buildTimeFilter('afternoon');
-  //   const eveningFilter = buildTimeFilter('evening');
-  //   expect(morningFilter(eveningToAfternoon)).toBe(true);
-  //   expect(afternoonFilter(eveningToAfternoon)).toBe(true);
-  //   expect(eveningFilter(eveningToAfternoon)).toBe(true);
-  // });
-
-  // it('correctly filters an event spanning morning to morning the following day', () => {
-  //   const morningToMorning = buildEvent({
-  //     startTime: '2018-08-02T09:00:00',
-  //     endTime: '2018-08-03T11:00:00'
-  //   });
-
-  //   const morningFilter = buildTimeFilter('morning');
-  //   const afternoonFilter = buildTimeFilter('afternoon');
-  //   const eveningFilter = buildTimeFilter('evening');
-  //   expect(morningFilter(morningToMorning)).toBe(true);
-  //   expect(afternoonFilter(morningToMorning)).toBe(true);
-  //   expect(eveningFilter(morningToMorning)).toBe(true);
-  // });
-});
-
-describe('buildCategoryFilter', () => {
-  const eventWithNoCategory = buildEvent({ eventCategories: [] });
-  const eventWithOneCategory = buildEvent({ eventCategories: ['Community'] });
-  const eventWithMulitpleCategories = buildEvent({
-    eventCategories: ['Community', 'Health']
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(afternoonToMorning)).toBe(true);
+    expect(afternoonFilter(afternoonToMorning)).toBe(true);
+    expect(eveningFilter(afternoonToMorning)).toBe(true);
   });
 
-  describe('when categories filter is an empty set', () => {
-    it('allows any event', () => {
+  it("correctly filters an event spanning evening to afternoon", () => {
+    const eveningToAfternoon = buildEvent({
+      startTime: "2018-08-02T20:00:00",
+      endTime: "2018-08-03T15:00:00"
+    });
+
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(eveningToAfternoon)).toBe(true);
+    expect(afternoonFilter(eveningToAfternoon)).toBe(true);
+    expect(eveningFilter(eveningToAfternoon)).toBe(true);
+  });
+
+  it("correctly filters an event spanning morning to morning the following day", () => {
+    const morningToMorning = buildEvent({
+      startTime: "2018-08-02T09:00:00",
+      endTime: "2018-08-03T10:00:00"
+    });
+
+    const morningFilter = buildTimeFilter("morning");
+    const afternoonFilter = buildTimeFilter("afternoon");
+    const eveningFilter = buildTimeFilter("evening");
+    expect(morningFilter(morningToMorning)).toBe(true);
+    expect(afternoonFilter(morningToMorning)).toBe(true);
+    expect(eveningFilter(morningToMorning)).toBe(true);
+  });
+});
+
+describe("buildCategoryFilter", () => {
+  const eventWithNoCategory = buildEvent({ eventCategories: [] });
+  const eventWithOneCategory = buildEvent({ eventCategories: ["Community"] });
+  const eventWithMulitpleCategories = buildEvent({
+    eventCategories: ["Community", "Health"]
+  });
+
+  describe("when categories filter is an empty set", () => {
+    it("allows any event", () => {
       const filter = buildCategoryFilter(new Set());
       expect(filter(eventWithNoCategory)).toBe(true);
       expect(filter(eventWithOneCategory)).toBe(true);
@@ -233,25 +240,25 @@ describe('buildCategoryFilter', () => {
     });
   });
 
-  describe('when categories filter contains one value', () => {
-    it('allows events which contain the same category', () => {
-      const filter = buildCategoryFilter(new Set(['Community']));
+  describe("when categories filter contains one value", () => {
+    it("allows events which contain the same category", () => {
+      const filter = buildCategoryFilter(new Set(["Community"]));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(true);
       expect(filter(eventWithMulitpleCategories)).toBe(true);
     });
 
-    it('does not allow events which do not match the category', () => {
-      const filter = buildCategoryFilter(new Set(['Nightlife']));
+    it("does not allow events which do not match the category", () => {
+      const filter = buildCategoryFilter(new Set(["Nightlife"]));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(false);
       expect(filter(eventWithMulitpleCategories)).toBe(false);
     });
   });
 
-  describe('when categories filter contains multiple values', () => {
-    it('allows only events which contain one of the same categories', () => {
-      const filter = buildCategoryFilter(new Set(['Community', 'Music']));
+  describe("when categories filter contains multiple values", () => {
+    it("allows only events which contain one of the same categories", () => {
+      const filter = buildCategoryFilter(new Set(["Community", "Music"]));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(true);
       expect(filter(eventWithMulitpleCategories)).toBe(true);
@@ -259,8 +266,8 @@ describe('buildCategoryFilter', () => {
   });
 });
 
-describe('buildPriceFilter', () => {
-  it('filters events that are not free', () => {
+describe("buildPriceFilter", () => {
+  it("filters events that are not free", () => {
     const event = buildEvent({
       eventPriceLow: 0,
       eventPriceHigh: 12
@@ -269,7 +276,7 @@ describe('buildPriceFilter', () => {
     expect(filter(event)).toBe(false);
   });
 
-  it('does not filter events that are free', () => {
+  it("does not filter events that are free", () => {
     const event = buildEvent({
       eventPriceLow: 0,
       eventPriceHigh: 0
@@ -279,37 +286,37 @@ describe('buildPriceFilter', () => {
   });
 });
 
-describe('buildStringSetFilter', () => {
+describe("buildStringSetFilter", () => {
   const eventWithNoValues = buildEvent({ eventCategories: [] });
-  const eventWithOneValue = buildEvent({ eventCategories: ['Community'] });
+  const eventWithOneValue = buildEvent({ eventCategories: ["Community"] });
   const eventWithMulitpleValues = buildEvent({
-    eventCategories: ['Community', 'Health']
+    eventCategories: ["Community", "Health"]
   });
 
-  describe('when string set filter is an empty set', () => {
-    it('allows any event', () => {
-      const filter = buildStringSetFilter('eventCategories', new Set());
+  describe("when string set filter is an empty set", () => {
+    it("allows any event", () => {
+      const filter = buildStringSetFilter("eventCategories", new Set());
       expect(filter(eventWithNoValues)).toBe(true);
       expect(filter(eventWithOneValue)).toBe(true);
       expect(filter(eventWithMulitpleValues)).toBe(true);
     });
   });
 
-  describe('when string set filter contains one value', () => {
-    it('allows events which contain the same category', () => {
+  describe("when string set filter contains one value", () => {
+    it("allows events which contain the same category", () => {
       const filter = buildStringSetFilter(
-        'eventCategories',
-        new Set(['Community'])
+        "eventCategories",
+        new Set(["Community"])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(true);
       expect(filter(eventWithMulitpleValues)).toBe(true);
     });
 
-    it('does not allow events which do not match the value', () => {
+    it("does not allow events which do not match the value", () => {
       const filter = buildStringSetFilter(
-        'eventCategories',
-        new Set(['Nightlife'])
+        "eventCategories",
+        new Set(["Nightlife"])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(false);
@@ -317,11 +324,11 @@ describe('buildStringSetFilter', () => {
     });
   });
 
-  describe('when string set filter contains multiple values', () => {
-    it('allows only events which contain one of the same categories', () => {
+  describe("when string set filter contains multiple values", () => {
+    it("allows only events which contain one of the same categories", () => {
       const filter = buildStringSetFilter(
-        'eventCategories',
-        new Set(['Community', 'Music'])
+        "eventCategories",
+        new Set(["Community", "Music"])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(true);
@@ -330,59 +337,59 @@ describe('buildStringSetFilter', () => {
   });
 });
 
-describe('buildAreaFilter', () => {
-  it('checks for North', () => {
+describe("buildAreaFilter", () => {
+  it("checks for North", () => {
     const event = buildEvent({
       location: {
         lon: -0.15343029999996816,
         lat: 51.5352875
       }
     });
-    expect(buildAreaFilter('North')(event)).toBe(true);
-    expect(buildAreaFilter('South')(event)).toBe(false);
+    expect(buildAreaFilter("North")(event)).toBe(true);
+    expect(buildAreaFilter("South")(event)).toBe(false);
   });
 
-  it('checks for South', () => {
+  it("checks for South", () => {
     const event = buildEvent({
       location: {
         lon: -0.14505099999996673,
         lat: 51.478269
       }
     });
-    expect(buildAreaFilter('South')(event)).toBe(true);
-    expect(buildAreaFilter('North')(event)).toBe(false);
+    expect(buildAreaFilter("South")(event)).toBe(true);
+    expect(buildAreaFilter("North")(event)).toBe(false);
   });
 
-  it('checks for East', () => {
+  it("checks for East", () => {
     const event = buildEvent({
       location: {
         lon: -0.032449100000008,
         lat: 51.5126187
       }
     });
-    expect(buildAreaFilter('East')(event)).toBe(true);
-    expect(buildAreaFilter('West')(event)).toBe(false);
+    expect(buildAreaFilter("East")(event)).toBe(true);
+    expect(buildAreaFilter("West")(event)).toBe(false);
   });
 
-  it('checks for West', () => {
+  it("checks for West", () => {
     const event = buildEvent({
       location: {
         lon: -0.21075725555419922,
         lat: 51.49629375642361
       }
     });
-    expect(buildAreaFilter('West')(event)).toBe(true);
-    expect(buildAreaFilter('East')(event)).toBe(false);
+    expect(buildAreaFilter("West")(event)).toBe(true);
+    expect(buildAreaFilter("East")(event)).toBe(false);
   });
 
-  it('checks for Central', () => {
+  it("checks for Central", () => {
     const event = buildEvent({
       location: {
         lon: -0.12488365173339844,
         lat: 51.49949975595735
       }
     });
-    expect(buildAreaFilter('Central')(event)).toBe(true);
-    expect(buildAreaFilter('North')(event)).toBe(false);
+    expect(buildAreaFilter("Central")(event)).toBe(true);
+    expect(buildAreaFilter("North")(event)).toBe(false);
   });
 });

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -6,8 +6,8 @@ import {
   buildPriceFilter,
   buildStringSetFilter,
   buildAreaFilter
-} from "./basic-event-filters";
-import type { Event, EventCategoryName } from "../data/event";
+} from './basic-event-filters';
+import type { Event, EventCategoryName } from '../data/event';
 
 export type BuildEventArguments = {
   startTime?: string,
@@ -22,8 +22,8 @@ export type BuildEventArguments = {
 };
 
 const buildEvent = ({
-  startTime = "2018-08-02T12:00:00",
-  endTime = "2018-08-05T12:00:00",
+  startTime = '2018-08-02T12:00:00',
+  endTime = '2018-08-05T12:00:00',
   eventCategories = [],
   eventPriceLow = 0,
   eventPriceHigh = 12,
@@ -34,129 +34,198 @@ const buildEvent = ({
 }: BuildEventArguments) =>
   (({
     fields: {
-      startTime: { "en-GB": startTime },
-      endTime: { "en-GB": endTime },
-      eventCategories: { "en-GB": eventCategories },
-      eventPriceLow: { "en-GB": eventPriceLow },
-      eventPriceHigh: { "en-GB": eventPriceHigh },
-      location: { "en-GB": location }
+      startTime: { 'en-GB': startTime },
+      endTime: { 'en-GB': endTime },
+      eventCategories: { 'en-GB': eventCategories },
+      eventPriceLow: { 'en-GB': eventPriceLow },
+      eventPriceHigh: { 'en-GB': eventPriceHigh },
+      location: { 'en-GB': location }
     }
   }: any): Event);
 
-describe("buildDateRangeFilter", () => {
+describe('buildDateRangeFilter', () => {
   const event = buildEvent({
-    startTime: "2018-08-02T12:00:00",
-    endTime: "2018-08-05T12:00:00"
+    startTime: '2018-08-02T12:00:00',
+    endTime: '2018-08-05T12:00:00'
   });
 
-  it("returns true when event starts within the given range", () => {
+  it('returns true when event starts within the given range', () => {
     const filter = buildDateRangeFilter({
-      startDate: "2018-08-01",
-      endDate: "2018-08-04"
+      startDate: '2018-08-01',
+      endDate: '2018-08-04'
     });
     expect(filter(event)).toBe(true);
   });
 
-  it("returns true when event ends within the given range", () => {
+  it('returns true when event ends within the given range', () => {
     const filter = buildDateRangeFilter({
-      startDate: "2018-08-04",
-      endDate: "2018-08-10"
+      startDate: '2018-08-04',
+      endDate: '2018-08-10'
     });
     expect(filter(event)).toBe(true);
   });
 
-  it("returns true when event starts before and ends after the given range", () => {
+  it('returns true when event starts before and ends after the given range', () => {
     const filter = buildDateRangeFilter({
-      startDate: "2018-08-01",
-      endDate: "2018-08-10"
+      startDate: '2018-08-01',
+      endDate: '2018-08-10'
     });
     expect(filter(event)).toBe(true);
   });
 
-  it("returns false otherwise", () => {
+  it('returns false otherwise', () => {
     const filter = buildDateRangeFilter({
-      startDate: "2018-07-29",
-      endDate: "2018-08-01"
+      startDate: '2018-07-29',
+      endDate: '2018-08-01'
     });
     expect(filter(event)).toBe(false);
   });
 });
 
-describe("buildTimeFilter", () => {
-  const event = buildEvent({
-    startTime: "2018-08-02T08:00:00",
-    endTime: "2018-08-02T15:00:00"
+describe('buildTimeFilter', () => {
+  // const event = buildEvent({
+  //   startTime: '2018-08-02T08:00:00',
+  //   endTime: '2018-08-02T15:00:00'
+  // });
+
+  it('recognises an event that starts and ends in the morning', () => {
+    const morningEvent = buildEvent({
+      startTime: '2018-08-02T06:00:00',
+      endTime: '2018-08-02T11:00:00'
+    });
+
+    const filter = buildTimeFilter('morning');
+    expect(filter(morningEvent)).toBe(true);
   });
 
-  it("checks for morning", () => {
-    const filter = buildTimeFilter("morning");
-    expect(filter(event)).toBe(true);
+  it('recognises an event that starts and ends in the afternoon', () => {
+    const afternoonEvent = buildEvent({
+      startTime: '2018-08-02T14:00:00',
+      endTime: '2018-08-02T15:00:00'
+    });
+    const filter = buildTimeFilter('afternoon');
+    expect(filter(afternoonEvent)).toBe(true);
   });
 
-  it("checks for afternoon", () => {
-    const filter = buildTimeFilter("afternoon");
-    expect(filter(event)).toBe(true);
-  });
-
-  it("checks for evening", () => {
-    const filter = buildTimeFilter("evening");
-    expect(filter(event)).toBe(false);
-  });
-});
-
-describe("buildTimeFilter - event from 2pm until midnight", () => {
-  const event = buildEvent({
-    startTime: "2018-08-02T14:00:00",
-    endTime: "2018-08-03T00:00:00"
-  });
-
-  it("checks for bugs in the morning", () => {
-    const filter = buildTimeFilter("morning");
-    expect(filter(event)).toBe(false);
-  });
-
-  it("checks for bugs in the afternoon", () => {
-    const filter = buildTimeFilter("afternoon");
-    expect(filter(event)).toBe(true);
-  });
-
-  it("checks for bugs in the evening", () => {
-    const filter = buildTimeFilter("evening");
-    expect(filter(event)).toBe(true);
+  it('recognises an event that starts and ends in the evening', () => {
+    const eveningEvent = buildEvent({
+      startTime: '2018-08-02T19:00:00',
+      endTime: '2018-08-02T23:00:00'
+    });
+    const filter = buildTimeFilter('evening');
+    expect(filter(eveningEvent)).toBe(true);
   });
 });
 
-describe("buildTimeFilter - an event from 11am until 8pm", () => {
-  const event = buildEvent({
-    startTime: "2018-08-02T11:00:00",
-    endTime: "2018-08-03T20:00:00"
+describe('events spanning multiple time slots', () => {
+  it('correctly filters an event spannig morning to afternoon', () => {
+    const morningToAfternoon = buildEvent({
+      startTime: '2018-08-02T09:00:00',
+      endTime: '2018-08-02T15:00:00'
+    });
+
+    const morningFilter = buildTimeFilter('morning');
+    const afternoonFilter = buildTimeFilter('afternoon');
+    const eveningFilter = buildTimeFilter('evening');
+    expect(morningFilter(morningToAfternoon)).toBe(true);
+    expect(afternoonFilter(morningToAfternoon)).toBe(true);
+    expect(eveningFilter(morningToAfternoon)).toBe(false);
   });
 
-  it("checks for bugs in the morning", () => {
-    const filter = buildTimeFilter("morning");
-    expect(filter(event)).toBe(true);
+  it('correctly filters an event spannig afternoon to evening', () => {
+    const afternoonToEvening = buildEvent({
+      startTime: '2018-08-02T14:00:00',
+      endTime: '2018-08-02T20:00:00'
+    });
+
+    const morningFilter = buildTimeFilter('morning');
+    const afternoonFilter = buildTimeFilter('afternoon');
+    const eveningFilter = buildTimeFilter('evening');
+    expect(morningFilter(afternoonToEvening)).toBe(false);
+    expect(afternoonFilter(afternoonToEvening)).toBe(true);
+    expect(eveningFilter(afternoonToEvening)).toBe(true);
   });
 
-  it("checks for bugs in the afternoon", () => {
-    const filter = buildTimeFilter("afternoon");
-    expect(filter(event)).toBe(true);
+  it('correctly filters an event spanning morning to evening', () => {
+    const morningToEvening = buildEvent({
+      startTime: '2018-08-02T09:00:00',
+      endTime: '2018-08-03T21:00:00'
+    });
+
+    const morningFilter = buildTimeFilter('morning');
+    const afternoonFilter = buildTimeFilter('afternoon');
+    const eveningFilter = buildTimeFilter('evening');
+    expect(morningFilter(morningToEvening)).toBe(true);
+    expect(afternoonFilter(morningToEvening)).toBe(true);
+    expect(eveningFilter(morningToEvening)).toBe(true);
   });
 
-  it("checks for bugs in the evening", () => {
-    const filter = buildTimeFilter("evening");
-    expect(filter(event)).toBe(true);
+  it('correctly filters an event spanning evening to morning', () => {
+    const eveningToMorning = buildEvent({
+      startTime: '2018-08-02T20:00:00',
+      endTime: '2018-08-03T08:00:00'
+    });
+
+    const morningFilter = buildTimeFilter('morning');
+    const afternoonFilter = buildTimeFilter('afternoon');
+    const eveningFilter = buildTimeFilter('evening');
+    expect(morningFilter(eveningToMorning)).toBe(true);
+    expect(afternoonFilter(eveningToMorning)).toBe(false);
+    expect(eveningFilter(eveningToMorning)).toBe(true);
   });
+
+  // it('correctly filters an event spanning afternoon to morning', () => {
+  //   const afternoonToMorning = buildEvent({
+  //     startTime: '2018-08-02T16:00:00',
+  //     endTime: '2018-08-03T11:00:00'
+  //   });
+
+  //   const morningFilter = buildTimeFilter('morning');
+  //   const afternoonFilter = buildTimeFilter('afternoon');
+  //   const eveningFilter = buildTimeFilter('evening');
+  //   expect(morningFilter(afternoonToMorning)).toBe(true);
+  //   expect(afternoonFilter(afternoonToMorning)).toBe(true);
+  //   expect(eveningFilter(afternoonToMorning)).toBe(true);
+  // });
+
+  // it('correctly filters an event spanning evening to afternoon', () => {
+  //   const eveningToAfternoon = buildEvent({
+  //     startTime: '2018-08-02T20:00:00',
+  //     endTime: '2018-08-03T06:00:00'
+  //   });
+
+  //   const morningFilter = buildTimeFilter('morning');
+  //   const afternoonFilter = buildTimeFilter('afternoon');
+  //   const eveningFilter = buildTimeFilter('evening');
+  //   expect(morningFilter(eveningToAfternoon)).toBe(true);
+  //   expect(afternoonFilter(eveningToAfternoon)).toBe(true);
+  //   expect(eveningFilter(eveningToAfternoon)).toBe(true);
+  // });
+
+  // it('correctly filters an event spanning morning to morning the following day', () => {
+  //   const morningToMorning = buildEvent({
+  //     startTime: '2018-08-02T09:00:00',
+  //     endTime: '2018-08-03T11:00:00'
+  //   });
+
+  //   const morningFilter = buildTimeFilter('morning');
+  //   const afternoonFilter = buildTimeFilter('afternoon');
+  //   const eveningFilter = buildTimeFilter('evening');
+  //   expect(morningFilter(morningToMorning)).toBe(true);
+  //   expect(afternoonFilter(morningToMorning)).toBe(true);
+  //   expect(eveningFilter(morningToMorning)).toBe(true);
+  // });
 });
 
-describe("buildCategoryFilter", () => {
+describe('buildCategoryFilter', () => {
   const eventWithNoCategory = buildEvent({ eventCategories: [] });
-  const eventWithOneCategory = buildEvent({ eventCategories: ["Community"] });
+  const eventWithOneCategory = buildEvent({ eventCategories: ['Community'] });
   const eventWithMulitpleCategories = buildEvent({
-    eventCategories: ["Community", "Health"]
+    eventCategories: ['Community', 'Health']
   });
 
-  describe("when categories filter is an empty set", () => {
-    it("allows any event", () => {
+  describe('when categories filter is an empty set', () => {
+    it('allows any event', () => {
       const filter = buildCategoryFilter(new Set());
       expect(filter(eventWithNoCategory)).toBe(true);
       expect(filter(eventWithOneCategory)).toBe(true);
@@ -164,25 +233,25 @@ describe("buildCategoryFilter", () => {
     });
   });
 
-  describe("when categories filter contains one value", () => {
-    it("allows events which contain the same category", () => {
-      const filter = buildCategoryFilter(new Set(["Community"]));
+  describe('when categories filter contains one value', () => {
+    it('allows events which contain the same category', () => {
+      const filter = buildCategoryFilter(new Set(['Community']));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(true);
       expect(filter(eventWithMulitpleCategories)).toBe(true);
     });
 
-    it("does not allow events which do not match the category", () => {
-      const filter = buildCategoryFilter(new Set(["Nightlife"]));
+    it('does not allow events which do not match the category', () => {
+      const filter = buildCategoryFilter(new Set(['Nightlife']));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(false);
       expect(filter(eventWithMulitpleCategories)).toBe(false);
     });
   });
 
-  describe("when categories filter contains multiple values", () => {
-    it("allows only events which contain one of the same categories", () => {
-      const filter = buildCategoryFilter(new Set(["Community", "Music"]));
+  describe('when categories filter contains multiple values', () => {
+    it('allows only events which contain one of the same categories', () => {
+      const filter = buildCategoryFilter(new Set(['Community', 'Music']));
       expect(filter(eventWithNoCategory)).toBe(false);
       expect(filter(eventWithOneCategory)).toBe(true);
       expect(filter(eventWithMulitpleCategories)).toBe(true);
@@ -190,8 +259,8 @@ describe("buildCategoryFilter", () => {
   });
 });
 
-describe("buildPriceFilter", () => {
-  it("filters events that are not free", () => {
+describe('buildPriceFilter', () => {
+  it('filters events that are not free', () => {
     const event = buildEvent({
       eventPriceLow: 0,
       eventPriceHigh: 12
@@ -200,7 +269,7 @@ describe("buildPriceFilter", () => {
     expect(filter(event)).toBe(false);
   });
 
-  it("does not filter events that are free", () => {
+  it('does not filter events that are free', () => {
     const event = buildEvent({
       eventPriceLow: 0,
       eventPriceHigh: 0
@@ -210,37 +279,37 @@ describe("buildPriceFilter", () => {
   });
 });
 
-describe("buildStringSetFilter", () => {
+describe('buildStringSetFilter', () => {
   const eventWithNoValues = buildEvent({ eventCategories: [] });
-  const eventWithOneValue = buildEvent({ eventCategories: ["Community"] });
+  const eventWithOneValue = buildEvent({ eventCategories: ['Community'] });
   const eventWithMulitpleValues = buildEvent({
-    eventCategories: ["Community", "Health"]
+    eventCategories: ['Community', 'Health']
   });
 
-  describe("when string set filter is an empty set", () => {
-    it("allows any event", () => {
-      const filter = buildStringSetFilter("eventCategories", new Set());
+  describe('when string set filter is an empty set', () => {
+    it('allows any event', () => {
+      const filter = buildStringSetFilter('eventCategories', new Set());
       expect(filter(eventWithNoValues)).toBe(true);
       expect(filter(eventWithOneValue)).toBe(true);
       expect(filter(eventWithMulitpleValues)).toBe(true);
     });
   });
 
-  describe("when string set filter contains one value", () => {
-    it("allows events which contain the same category", () => {
+  describe('when string set filter contains one value', () => {
+    it('allows events which contain the same category', () => {
       const filter = buildStringSetFilter(
-        "eventCategories",
-        new Set(["Community"])
+        'eventCategories',
+        new Set(['Community'])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(true);
       expect(filter(eventWithMulitpleValues)).toBe(true);
     });
 
-    it("does not allow events which do not match the value", () => {
+    it('does not allow events which do not match the value', () => {
       const filter = buildStringSetFilter(
-        "eventCategories",
-        new Set(["Nightlife"])
+        'eventCategories',
+        new Set(['Nightlife'])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(false);
@@ -248,11 +317,11 @@ describe("buildStringSetFilter", () => {
     });
   });
 
-  describe("when string set filter contains multiple values", () => {
-    it("allows only events which contain one of the same categories", () => {
+  describe('when string set filter contains multiple values', () => {
+    it('allows only events which contain one of the same categories', () => {
       const filter = buildStringSetFilter(
-        "eventCategories",
-        new Set(["Community", "Music"])
+        'eventCategories',
+        new Set(['Community', 'Music'])
       );
       expect(filter(eventWithNoValues)).toBe(false);
       expect(filter(eventWithOneValue)).toBe(true);
@@ -261,59 +330,59 @@ describe("buildStringSetFilter", () => {
   });
 });
 
-describe("buildAreaFilter", () => {
-  it("checks for North", () => {
+describe('buildAreaFilter', () => {
+  it('checks for North', () => {
     const event = buildEvent({
       location: {
         lon: -0.15343029999996816,
         lat: 51.5352875
       }
     });
-    expect(buildAreaFilter("North")(event)).toBe(true);
-    expect(buildAreaFilter("South")(event)).toBe(false);
+    expect(buildAreaFilter('North')(event)).toBe(true);
+    expect(buildAreaFilter('South')(event)).toBe(false);
   });
 
-  it("checks for South", () => {
+  it('checks for South', () => {
     const event = buildEvent({
       location: {
         lon: -0.14505099999996673,
         lat: 51.478269
       }
     });
-    expect(buildAreaFilter("South")(event)).toBe(true);
-    expect(buildAreaFilter("North")(event)).toBe(false);
+    expect(buildAreaFilter('South')(event)).toBe(true);
+    expect(buildAreaFilter('North')(event)).toBe(false);
   });
 
-  it("checks for East", () => {
+  it('checks for East', () => {
     const event = buildEvent({
       location: {
         lon: -0.032449100000008,
         lat: 51.5126187
       }
     });
-    expect(buildAreaFilter("East")(event)).toBe(true);
-    expect(buildAreaFilter("West")(event)).toBe(false);
+    expect(buildAreaFilter('East')(event)).toBe(true);
+    expect(buildAreaFilter('West')(event)).toBe(false);
   });
 
-  it("checks for West", () => {
+  it('checks for West', () => {
     const event = buildEvent({
       location: {
         lon: -0.21075725555419922,
         lat: 51.49629375642361
       }
     });
-    expect(buildAreaFilter("West")(event)).toBe(true);
-    expect(buildAreaFilter("East")(event)).toBe(false);
+    expect(buildAreaFilter('West')(event)).toBe(true);
+    expect(buildAreaFilter('East')(event)).toBe(false);
   });
 
-  it("checks for Central", () => {
+  it('checks for Central', () => {
     const event = buildEvent({
       location: {
         lon: -0.12488365173339844,
         lat: 51.49949975595735
       }
     });
-    expect(buildAreaFilter("Central")(event)).toBe(true);
-    expect(buildAreaFilter("North")(event)).toBe(false);
+    expect(buildAreaFilter('Central')(event)).toBe(true);
+    expect(buildAreaFilter('North')(event)).toBe(false);
   });
 });

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -104,16 +104,16 @@ describe("buildTimeFilter", () => {
   });
 });
 
-describe("bug busting the buildTimeFilter for overnight events", () => {
+describe("bug busting the buildTimeFilter for events that end at midnight", () => {
   const buggyEvent = buildEvent({
     startTime: "2018-08-02T14:00:00",
     endTime: "2018-08-03T00:00:00"
   });
 
-  const happyEvent = buildEvent({
-    startTime: "2018-08-02T14:00:00",
-    endTime: "2018-08-02T23:59:00"
-  });
+  // const happyEvent = buildEvent({
+  //   startTime: "2018-08-02T14:00:00",
+  //   endTime: "2018-08-02T23:59:00"
+  // });
 
   it("checks for bugs in the morning", () => {
     const filter = buildTimeFilter("morning");
@@ -130,6 +130,8 @@ describe("bug busting the buildTimeFilter for overnight events", () => {
     expect(filter(buggyEvent)).toBe(true);
   });
 });
+
+// TODO - Create events that span varying times
 
 describe("buildCategoryFilter", () => {
   const eventWithNoCategory = buildEvent({ eventCategories: [] });

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -104,6 +104,33 @@ describe("buildTimeFilter", () => {
   });
 });
 
+describe("bug busting the buildTimeFilter for overnight events", () => {
+  const buggyEvent = buildEvent({
+    startTime: "2018-08-02T14:00:00",
+    endTime: "2018-08-03T00:00:00"
+  });
+
+  const happyEvent = buildEvent({
+    startTime: "2018-08-02T14:00:00",
+    endTime: "2018-08-02T23:59:00"
+  });
+
+  it("checks for bugs in the morning", () => {
+    const filter = buildTimeFilter("morning");
+    expect(filter(buggyEvent)).toBe(false);
+  });
+
+  it("checks for bugs in the afternoon", () => {
+    const filter = buildTimeFilter("afternoon");
+    expect(filter(buggyEvent)).toBe(true);
+  });
+
+  it("checks for bugs in the evening", () => {
+    const filter = buildTimeFilter("evening");
+    expect(filter(buggyEvent)).toBe(true);
+  });
+});
+
 describe("buildCategoryFilter", () => {
   const eventWithNoCategory = buildEvent({ eventCategories: [] });
   const eventWithOneCategory = buildEvent({ eventCategories: ["Community"] });

--- a/src/selectors/basic-event-filters.test.js
+++ b/src/selectors/basic-event-filters.test.js
@@ -104,34 +104,49 @@ describe("buildTimeFilter", () => {
   });
 });
 
-describe("bug busting the buildTimeFilter for events that end at midnight", () => {
-  const buggyEvent = buildEvent({
+describe("buildTimeFilter - event from 2pm until midnight", () => {
+  const event = buildEvent({
     startTime: "2018-08-02T14:00:00",
     endTime: "2018-08-03T00:00:00"
   });
 
-  // const happyEvent = buildEvent({
-  //   startTime: "2018-08-02T14:00:00",
-  //   endTime: "2018-08-02T23:59:00"
-  // });
-
   it("checks for bugs in the morning", () => {
     const filter = buildTimeFilter("morning");
-    expect(filter(buggyEvent)).toBe(false);
+    expect(filter(event)).toBe(false);
   });
 
   it("checks for bugs in the afternoon", () => {
     const filter = buildTimeFilter("afternoon");
-    expect(filter(buggyEvent)).toBe(true);
+    expect(filter(event)).toBe(true);
   });
 
   it("checks for bugs in the evening", () => {
     const filter = buildTimeFilter("evening");
-    expect(filter(buggyEvent)).toBe(true);
+    expect(filter(event)).toBe(true);
   });
 });
 
-// TODO - Create events that span varying times
+describe("buildTimeFilter - an event from 11am until 8pm", () => {
+  const event = buildEvent({
+    startTime: "2018-08-02T11:00:00",
+    endTime: "2018-08-03T20:00:00"
+  });
+
+  it("checks for bugs in the morning", () => {
+    const filter = buildTimeFilter("morning");
+    expect(filter(event)).toBe(false);
+  });
+
+  it("checks for bugs in the afternoon", () => {
+    const filter = buildTimeFilter("afternoon");
+    expect(filter(event)).toBe(true);
+  });
+
+  it("checks for bugs in the evening", () => {
+    const filter = buildTimeFilter("evening");
+    expect(filter(event)).toBe(true);
+  });
+});
 
 describe("buildCategoryFilter", () => {
   const eventWithNoCategory = buildEvent({ eventCategories: [] });


### PR DESCRIPTION
Fixes #183

The buildTimeFilter does not currently handle end times that are the following day to the start date., hence the above bug.

WIP
* [x] Unit tests

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
