### PR TITLE
Ignore platform folders in flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -23,6 +23,12 @@
 ; Ignore metro
 .*/node_modules/metro/.*
 
+; Ignore iOS platform
+.*/ios/.*
+
+; Ignore Android platform
+.*/android/.*
+
 .*/node_modules/config-chain/.*
 
 [include]


### PR DESCRIPTION
Because I have all the tooling installed locally `flow` picks up files from the ruby gems inside the ios folder.

Also pretty sure specifying a folder when calling flow isn't a thing as it's already `flow src` but it still checks all the files so this will shave some time off when running flow as the server won't be parsing all the native projects files.