### PR TITLE
Remove isFree and timeOfDay from event data

### DIFF
--- a/src/screens/EventDetailsScreen/EventDescription.test.js
+++ b/src/screens/EventDetailsScreen/EventDescription.test.js
@@ -58,7 +58,6 @@ it("renders correctly", () => {
           "Music"
         ]
       },
-      timeOfDay: { "en-GB": ["Afternoon"] },
       recurrenceDates: { "en-GB": ["13/1/18", "15/1/18"] },
       accessibilityDetails: {
         "en-GB":

--- a/src/screens/EventDetailsScreen/EventOverview.test.js
+++ b/src/screens/EventDetailsScreen/EventOverview.test.js
@@ -61,7 +61,6 @@ const defaultEvent: Event = ({
         "Music"
       ]
     },
-    timeOfDay: { "en-GB": ["Afternoon"] },
     recurrenceDates: {
       "en-GB": [
         "10/07/2018",

--- a/src/screens/EventDetailsScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/EventDetailsScreen/__snapshots__/component.test.js.snap
@@ -298,11 +298,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                     "ticketingUrl": Object {
                       "en-GB": "https://prideinlondon.org/pride-in-the-park/",
                     },
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",
@@ -419,11 +414,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                     "ticketingUrl": Object {
                       "en-GB": "https://prideinlondon.org/pride-in-the-park/",
                     },
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",
@@ -534,11 +524,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                     },
                     "ticketingUrl": Object {
                       "en-GB": "https://prideinlondon.org/pride-in-the-park/",
-                    },
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
                     },
                     "venueDetails": Object {
                       "en-GB": Array [
@@ -665,11 +650,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                     "ticketingUrl": Object {
                       "en-GB": "https://prideinlondon.org/pride-in-the-park/",
                     },
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",
@@ -789,11 +769,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
           },
           "ticketingUrl": Object {
             "en-GB": "https://prideinlondon.org/pride-in-the-park/",
-          },
-          "timeOfDay": Object {
-            "en-GB": Array [
-              "Afternoon",
-            ],
           },
           "venueDetails": Object {
             "en-GB": Array [
@@ -983,11 +958,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                       "en-GB": "2017-07-09T11:00+01:00",
                     },
                     "ticketingUrl": undefined,
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",
@@ -1100,11 +1070,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                       "en-GB": "2017-07-09T11:00+01:00",
                     },
                     "ticketingUrl": undefined,
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",
@@ -1212,11 +1177,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
                       "en-GB": "2017-07-09T11:00+01:00",
                     },
                     "ticketingUrl": undefined,
-                    "timeOfDay": Object {
-                      "en-GB": Array [
-                        "Afternoon",
-                      ],
-                    },
                     "venueDetails": Object {
                       "en-GB": Array [
                         "Gender neutral toilets",

--- a/src/screens/EventDetailsScreen/component.test.js
+++ b/src/screens/EventDetailsScreen/component.test.js
@@ -63,7 +63,6 @@ const event: Event = ({
         "Music"
       ]
     },
-    timeOfDay: { "en-GB": ["Afternoon"] },
     recurrenceDates: { "en-GB": ["13/1/18", "15/1/18"] },
     accessibilityDetails: {
       "en-GB":

--- a/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SavedEventListScreen/__snapshots__/component.test.js.snap
@@ -116,11 +116,6 @@ Pink for Pink tours will be putting the movers, shakers and shimmiers under a la
               "ticketingUrl": Object {
                 "en-GB": "https://prideinlondon.org/pride-in-the-park/",
               },
-              "timeOfDay": Object {
-                "en-GB": Array [
-                  "Afternoon",
-                ],
-              },
               "venueDetails": Object {
                 "en-GB": Array [
                   "Gender neutral toilets",

--- a/src/screens/SavedEventListScreen/component.test.js
+++ b/src/screens/SavedEventListScreen/component.test.js
@@ -65,7 +65,6 @@ describe("SavedEventListScreen Component", () => {
           "Music"
         ]
       },
-      timeOfDay: { "en-GB": ["Afternoon"] },
       recurrenceDates: { "en-GB": ["13/1/18", "15/1/18"] },
       accessibilityDetails: {
         "en-GB":


### PR DESCRIPTION
Closes #295. TLDR; we don't use `isFree` nor `timeOfDay` directly so do not have a dependency on them. This PR removes the final traces. Once this is merged I will disable them in contentful.