### PR TITLE
Fix: Too much space below status bar

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,6 @@
 // @flow
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
 import type { Node } from "react";
 import ContentPadding from "./ContentPadding";
 import IconButton from "./IconButton";

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -18,11 +18,7 @@ type Props = {
 };
 
 const Header = ({ leftElement, title, rightElement, testID }: Props) => (
-  <SafeAreaView
-    accessibilityTraits={["header"]}
-    style={styles.container}
-    forceInset={{ top: "always" }}
-  >
+  <View accessibilityTraits={["header"]} style={styles.container}>
     <ContentPadding style={styles.headerContent}>
       <View style={styles.first}>{leftElement}</View>
       <View style={styles.title}>
@@ -32,7 +28,7 @@ const Header = ({ leftElement, title, rightElement, testID }: Props) => (
       </View>
       <View style={styles.last}>{rightElement}</View>
     </ContentPadding>
-  </SafeAreaView>
+  </View>
 );
 
 Header.defaultProps = {

--- a/src/components/__snapshots__/Header.test.js.snap
+++ b/src/components/__snapshots__/Header.test.js.snap
@@ -1,16 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header renders correctly with all props 1`] = `
-<withOrientation
+<Component
   accessibilityTraits={
     Array [
       "header",
     ]
-  }
-  forceInset={
-    Object {
-      "top": "always",
-    }
   }
   style={
     Object {
@@ -85,20 +80,15 @@ exports[`Header renders correctly with all props 1`] = `
       </Text>
     </Component>
   </ContentPadding>
-</withOrientation>
+</Component>
 `;
 
 exports[`Header renders correctly with default props 1`] = `
-<withOrientation
+<Component
   accessibilityTraits={
     Array [
       "header",
     ]
-  }
-  forceInset={
-    Object {
-      "top": "always",
-    }
   }
   style={
     Object {
@@ -155,20 +145,15 @@ exports[`Header renders correctly with default props 1`] = `
       }
     />
   </ContentPadding>
-</withOrientation>
+</Component>
 `;
 
 exports[`Header renders correctly with only onBack and rightElement 1`] = `
-<withOrientation
+<Component
   accessibilityTraits={
     Array [
       "header",
     ]
-  }
-  forceInset={
-    Object {
-      "top": "always",
-    }
   }
   style={
     Object {
@@ -241,20 +226,15 @@ exports[`Header renders correctly with only onBack and rightElement 1`] = `
       </Text>
     </Component>
   </ContentPadding>
-</withOrientation>
+</Component>
 `;
 
 exports[`Header renders correctly with only title 1`] = `
-<withOrientation
+<Component
   accessibilityTraits={
     Array [
       "header",
     ]
-  }
-  forceInset={
-    Object {
-      "top": "always",
-    }
   }
   style={
     Object {
@@ -313,7 +293,7 @@ exports[`Header renders correctly with only title 1`] = `
       }
     />
   </ContentPadding>
-</withOrientation>
+</Component>
 `;
 
 exports[`Header.BackButton renders correctly with default props 1`] = `


### PR DESCRIPTION
Fixes #290. TLDR; the App and Header component were both forcing the SafeArea on iOS. This PR removes it from the Header.

![image](https://user-images.githubusercontent.com/3579251/39959500-6bfa7296-560a-11e8-97d2-ffd25e4dff4a.png)
