### PR TITLE
Increase size of Heart icon on Android

### DIFF
--- a/src/screens/SavedEventListScreen/NoSavedEvents.js
+++ b/src/screens/SavedEventListScreen/NoSavedEvents.js
@@ -1,6 +1,12 @@
 // @flow
 import React, { PureComponent } from "react";
-import { Image, StyleSheet, ScrollView } from "react-native";
+import {
+  Image,
+  PixelRatio,
+  Platform,
+  StyleSheet,
+  ScrollView
+} from "react-native";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
 import Text from "../../components/Text";
 import ButtonPrimary from "../../components/ButtonPrimary";
@@ -9,7 +15,6 @@ import ContentPadding from "../../components/ContentPadding";
 import iconSave from "../../../assets/images/save.png";
 import noSavedEvents from "../../../assets/images/howToSaveEvents.png";
 import text from "../../constants/text";
-import { lightNavyBlueColor } from "../../constants/colors";
 import { EVENT_LIST } from "../../constants/routes";
 
 type Props = {
@@ -27,7 +32,7 @@ class NoSavedEvents extends PureComponent<Props> {
         <ContentPadding style={styles.container}>
           <LayoutColumn spacing={12}>
             <Image style={styles.image} source={noSavedEvents} />
-            <Text type="h1" style={styles.title}>
+            <Text type="h1" color="lightNavyBlueColor" style={styles.title}>
               {text.noSavedEventsTitle}
             </Text>
             <Text
@@ -37,7 +42,7 @@ class NoSavedEvents extends PureComponent<Props> {
               } ${text.noSavedEventsPart2}`}
             >
               {text.noSavedEventsPart1}&nbsp;
-              <Image source={iconSave} />
+              <Image style={styles.heart} source={iconSave} />
               &nbsp;{text.noSavedEventsPart2}
             </Text>
             <ButtonPrimary onPress={this.eventList}>
@@ -50,16 +55,23 @@ class NoSavedEvents extends PureComponent<Props> {
   }
 }
 
+// Fix for Android rendering Image inline with Text.
+const heartWidth = 24 * (Platform.OS === "ios" ? 1 : PixelRatio.get());
+const heartHeight = 21 * (Platform.OS === "ios" ? 1 : PixelRatio.get());
+
 const styles = StyleSheet.create({
   container: {
     flex: 3,
     marginBottom: 12
   },
+  heart: {
+    width: heartWidth,
+    height: heartHeight
+  },
   image: {
     alignSelf: "center"
   },
   title: {
-    color: lightNavyBlueColor,
     textAlign: "center"
   },
   infoText: {

--- a/src/screens/SavedEventListScreen/__snapshots__/NoSavedEvents.test.js.snap
+++ b/src/screens/SavedEventListScreen/__snapshots__/NoSavedEvents.test.js.snap
@@ -23,12 +23,11 @@ exports[`renders correctly 1`] = `
         }
       />
       <Text
-        color="blackColor"
+        color="lightNavyBlueColor"
         markdown={false}
         markdownStyle={Object {}}
         style={
           Object {
-            "color": "#2d2f7f",
             "textAlign": "center",
           }
         }
@@ -54,6 +53,12 @@ event you like to save them here."
          
         <Image
           source={1}
+          style={
+            Object {
+              "height": 21,
+              "width": 24,
+            }
+          }
         />
          
         on any 


### PR DESCRIPTION
Fixes #211.

**Note:** I could not find a way to vertically center the image on Android so I think we will have to do with it sitting on the baseline of the text. If anyone else can find a way, let me know.

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)