### PR TITLE
add core-js to polyfill padStart on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "bugsnag-react-native": "^2.9.3",
     "contentful": "^5.0.5",
+    "core-js": "^2.5.6",
     "date-fns": "^1.29.0",
     "lottie-react-native": "2.3.2",
     "ramda": "^0.25.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+import "core-js/modules/es7.string.pad-start";
 import React, { Component } from "react";
 import { YellowBox } from "react-native";
 import { createStore, applyMiddleware } from "redux";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,10 @@ core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
+core-js@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
Fixes #300. TLDR; Android does not currently have String.prototype.padStart available, hence the app crashes. This PR adds it via core-js.