### PR TITLE
305: Filter recurring events happening on same day

### DIFF
--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -128,7 +128,14 @@ export const expandRecurringEventsInEntries = entries =>
 
     if (shouldExpandEvent) {
       const clones = recurrenceDates.map(generateRecurringEvent(curr));
-      return [...acc, curr, ...clones];
+
+      const expandedEvents = R.uniqWith(
+        (a: Event, b: Event) =>
+          isSameDay(a.fields.startTime[locale], b.fields.startTime[locale]),
+        [curr, ...clones]
+      );
+
+      return [...acc, ...expandedEvents];
     }
     return [...acc, curr];
   }, []);

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -418,6 +418,46 @@ describe("expandRecurringEventsInEntries", () => {
     expect(expandRecurringEventsInEntries(events)).toEqual(expected);
   });
 
+  it("does not create new events recurrence is on the same day as start date", () => {
+    const events = [
+      {
+        fields: {
+          startTime: { "en-GB": "2018-08-02T00:00+00:00" },
+          endTime: { "en-GB": "2018-08-02T04:00+00:00" },
+          recurrenceDates: { "en-GB": ["02/08/2018"] }
+        },
+        sys: {
+          id: "event1",
+          contentType: { sys: { id: "event" } }
+        }
+      },
+      {
+        fields: { startTime: { "en-GB": "2018-08-01T00:00+00:00" } },
+        sys: { id: "event2", contentType: { sys: { id: "event" } } }
+      }
+    ];
+
+    const expected = [
+      {
+        fields: {
+          startTime: { "en-GB": "2018-08-02T00:00+00:00" },
+          endTime: { "en-GB": "2018-08-02T04:00+00:00" },
+          recurrenceDates: { "en-GB": ["02/08/2018"] }
+        },
+        sys: {
+          id: "event1",
+          contentType: { sys: { id: "event" } }
+        }
+      },
+      {
+        fields: { startTime: { "en-GB": "2018-08-01T00:00+00:00" } },
+        sys: { id: "event2", contentType: { sys: { id: "event" } } }
+      }
+    ];
+
+    expect(expandRecurringEventsInEntries(events)).toEqual(expected);
+  });
+
   it("does not modify endTime if on different day to startTime", () => {
     const events = [
       {


### PR DESCRIPTION
Fixes #305 

This bug was due to one of the recurrence dates being on the same day as the event start date. So not strictly a bug.

This PR only creates recurring events if they are on unique days. If that is the functionality that we need then this should work. Otherwise we can just ditch it.

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [ ] Unit tests

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [x] Galaxy S8 (Android 7.0/8.0)
  * [x] Galaxy S7 (Android 6.0)
  * [x] iPhone X (iOS 11.x)
  * [x] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [x] iPhone 7+
  * [x] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings

![](https://thumbs.gfycat.com/MaleTenderGoat-size_restricted.gif)