### PR TITLE
Fix the version of react native in gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -237,7 +237,7 @@ dependencies {
     implementation project(':react-native-config')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.facebook.react:react-native:0.55.4"  // From node_modules
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
         transitive = true
     }


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/19259

The above issue didn't affect us as we are already on the latest version of React Native but it's recommended to fix the version of React Native in both package.json and gradle files as upcoming changes from Google will make this an issue.
