### PR TITLE
312: Fix events with duplicate recurrence dates.

### DIFF
--- a/src/reducers/events.test.js
+++ b/src/reducers/events.test.js
@@ -97,7 +97,7 @@ describe("Events reducer", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018",
+          id: "event1-recurrence-03/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       }

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -58,7 +58,7 @@ export const groupEventsByStartTime = (events: Event[]): EventDays => {
     : sections.days;
 };
 
-const generateRecurringEvent = event => recurrance => {
+const generateRecurringEvent = event => (recurrance, i) => {
   const [recurranceDay, recurrancyMonth, recurranceYear] = recurrance.split(
     "/"
   );
@@ -106,7 +106,7 @@ const generateRecurringEvent = event => recurrance => {
       }
     },
     sys: {
-      id: `${event.sys.id}-recurrence-${recurrance}`
+      id: `${event.sys.id}-recurrence-${recurrance}-${i}`
     }
   });
 };

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -322,7 +322,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018",
+          id: "event1-recurrence-03/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -367,7 +367,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "3/8/2018"] }
         },
         sys: {
-          id: "event1-recurrence-3/8/2018",
+          id: "event1-recurrence-3/8/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -388,7 +388,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018",
+          id: "event1-recurrence-03/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -405,7 +405,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018",
+          id: "event1-recurrence-03/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -450,7 +450,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018",
+          id: "event1-recurrence-03/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -495,7 +495,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "06/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-06/08/2018",
+          id: "event1-recurrence-06/08/2018-0",
           contentType: { sys: { id: "event" } }
         }
       },


### PR DESCRIPTION
Fixes #312 

Events were using the recurrence date in their Id (and in their event list key). When events had duplicate dates they shared an ID and had weird behaviour.

This PR just includes the array index of the recurrence date, in the generated event ID.

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [ ] Unit tests

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings

![](https://thumbs.gfycat.com/NippyHugeKilldeer-size_restricted.gif)