### PR TITLE
Revert "312: Fix events with duplicate recurrence dates."

### DIFF
--- a/src/reducers/events.test.js
+++ b/src/reducers/events.test.js
@@ -97,7 +97,7 @@ describe("Events reducer", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018-0",
+          id: "event1-recurrence-03/08/2018",
           contentType: { sys: { id: "event" } }
         }
       }

--- a/src/selectors/events.js
+++ b/src/selectors/events.js
@@ -58,7 +58,7 @@ export const groupEventsByStartTime = (events: Event[]): EventDays => {
     : sections.days;
 };
 
-const generateRecurringEvent = event => (recurrance, i) => {
+const generateRecurringEvent = event => recurrance => {
   const [recurranceDay, recurrancyMonth, recurranceYear] = recurrance.split(
     "/"
   );
@@ -106,7 +106,7 @@ const generateRecurringEvent = event => (recurrance, i) => {
       }
     },
     sys: {
-      id: `${event.sys.id}-recurrence-${recurrance}-${i}`
+      id: `${event.sys.id}-recurrence-${recurrance}`
     }
   });
 };

--- a/src/selectors/events.test.js
+++ b/src/selectors/events.test.js
@@ -322,7 +322,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018-0",
+          id: "event1-recurrence-03/08/2018",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -367,7 +367,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "3/8/2018"] }
         },
         sys: {
-          id: "event1-recurrence-3/8/2018-0",
+          id: "event1-recurrence-3/8/2018",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -388,7 +388,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018-0",
+          id: "event1-recurrence-03/08/2018",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -405,7 +405,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018-0",
+          id: "event1-recurrence-03/08/2018",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -450,7 +450,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "03/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-03/08/2018-0",
+          id: "event1-recurrence-03/08/2018",
           contentType: { sys: { id: "event" } }
         }
       },
@@ -495,7 +495,7 @@ describe("expandRecurringEventsInEntries", () => {
           recurrenceDates: { "en-GB": ["02/08/2018", "06/08/2018"] }
         },
         sys: {
-          id: "event1-recurrence-06/08/2018-0",
+          id: "event1-recurrence-06/08/2018",
           contentType: { sys: { id: "event" } }
         }
       },


### PR DESCRIPTION
@RGBboy Made a very good point on the original PR for this change (#313):

> I think this will open up the chance that saved events disappear. If a recurrence is removed, any recurrences later in the list will now have a different id and therefore not matched the previously saved id.

Which I think is true. Since the bug that this PR fixes was also fixed in #309 I think I'll revert #313 and just merge #309 