### PR TITLE
Fix filter back gesture

### DIFF
--- a/src/actions/event-filters.js
+++ b/src/actions/event-filters.js
@@ -14,7 +14,9 @@ type EventFiltersActionType =
   | "SET_EVENT_FILTERS"
   | "STAGE_EVENT_FILTERS"
   | "COMMIT_EVENT_FILTERS"
-  | "CLEAR_STAGED_EVENT_FILTERS";
+  | "CLEAR_STAGED_EVENT_FILTERS"
+  | "CLEAR_EVENT_FILTERS";
+
 type EventFiltersPayload = {
   date?: ?DateRange,
   timeOfDay?: Set<Time>,
@@ -56,3 +58,7 @@ export const commitEventFilters = () => (
 export const clearStagedEventFilters = () => (
   dispatch: Dispatch<EventFiltersAction>
 ) => dispatch({ type: "CLEAR_STAGED_EVENT_FILTERS" });
+
+export const clearEventFilters = () => (
+  dispatch: Dispatch<EventFiltersAction>
+) => dispatch({ type: "CLEAR__EVENT_FILTERS" });

--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -139,6 +139,7 @@ class EventList extends Component<Props> {
         SectionSeparatorComponent={separator(styles.sectionSeparator)}
         refreshing={refreshing}
         onRefresh={onRefresh}
+        windowSize={10}
       />
     );
   }

--- a/src/components/__snapshots__/EventList.test.js.snap
+++ b/src/components/__snapshots__/EventList.test.js.snap
@@ -165,7 +165,7 @@ exports[`EventList renders correctly 1`] = `
   }
   stickySectionHeadersEnabled={true}
   updateCellsBatchingPeriod={50}
-  windowSize={21}
+  windowSize={10}
 />
 `;
 

--- a/src/reducers/__snapshots__/route.test.js.snap
+++ b/src/reducers/__snapshots__/route.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Router reducer NAVIGATE action stores the current route 1`] = `"somewhere"`;
+
+exports[`Router reducer initialises with default state 1`] = `""`;

--- a/src/reducers/__snapshots__/route.test.js.snap
+++ b/src/reducers/__snapshots__/route.test.js.snap
@@ -2,4 +2,6 @@
 
 exports[`Router reducer NAVIGATE action stores the current route 1`] = `"somewhere"`;
 
+exports[`Router reducer NAVIGATION action stores the current route 1`] = `"somewhere"`;
+
 exports[`Router reducer initialises with default state 1`] = `""`;

--- a/src/reducers/__snapshots__/route.test.js.snap
+++ b/src/reducers/__snapshots__/route.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Router reducer NAVIGATE action stores the current route 1`] = `"somewhere"`;
-
 exports[`Router reducer NAVIGATION action stores the current route 1`] = `"somewhere"`;
 
 exports[`Router reducer initialises with default state 1`] = `""`;

--- a/src/reducers/event-filters.js
+++ b/src/reducers/event-filters.js
@@ -57,6 +57,10 @@ const eventFilters: Reducer<State, EventFiltersAction> = (
         ...state,
         stagedFilters: state.selectedFilters
       };
+    case "CLEAR_EVENT_FILTERS":
+      return {
+        ...defaultState
+      };
     default:
       return state;
   }

--- a/src/reducers/event-filters.test.js
+++ b/src/reducers/event-filters.test.js
@@ -183,4 +183,46 @@ describe("Event filters reducer", () => {
     // this is used by selectIsStagingFilters
     expect(state.stagedFilters).toBe(state.selectedFilters);
   });
+
+  it("clears the event filters for CLEAR_EVENT_FILTERS action", () => {
+    const initialState = {
+      selectedFilters: {
+        categories: new Set(),
+        date: { startDate: "2018-03-12", endDate: "2018-03-12" },
+        timeOfDay: new Set(),
+        price: new Set(),
+        audience: new Set(),
+        venueDetails: new Set(),
+        accessibilityOptions: new Set(),
+        area: new Set()
+      },
+      stagedFilters: {
+        categories: new Set(),
+        date: { startDate: "2018-03-20", endDate: "2018-03-20" },
+        timeOfDay: new Set(),
+        price: new Set(),
+        audience: new Set(),
+        venueDetails: new Set(),
+        accessibilityOptions: new Set(),
+        area: new Set()
+      }
+    };
+    const state = reducer(initialState, {
+      type: "CLEAR_EVENT_FILTERS"
+    });
+
+    const emptyFilters = {
+      categories: new Set(), // When this is empty it signifies no category filter.
+      date: null,
+      timeOfDay: new Set(),
+      price: new Set(),
+      audience: new Set(),
+      venueDetails: new Set(),
+      accessibilityOptions: new Set(),
+      area: new Set()
+    };
+
+    expect(state.stagedFilters).toEqual(emptyFilters);
+    expect(state.selectedFilters).toEqual(emptyFilters);
+  });
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,15 +6,20 @@ import eventFilters from "./event-filters";
 import type { State as EventFiltersState } from "../data/event-filters";
 import savedEvents from "./saved-events";
 import type { SavedEvents as SavedEventsState } from "../data/event";
+import currentRoute from "./route";
+
+type Route = string;
 
 export type State = {
   events: EventsState,
   eventFilters: EventFiltersState,
-  savedEvents: SavedEventsState
+  savedEvents: SavedEventsState,
+  currentRoute: Route
 };
 
 export default combineReducers({
   events,
   eventFilters,
-  savedEvents
+  savedEvents,
+  currentRoute
 });

--- a/src/reducers/route.js
+++ b/src/reducers/route.js
@@ -1,0 +1,19 @@
+// @flow
+import type { Reducer } from "redux";
+import type { NavigationAction } from "../actions/navigation";
+
+export type State = string;
+const defaultState = "";
+
+const events: Reducer<State, NavigationAction> = (
+  state: State = defaultState,
+  action: NavigationAction
+) => {
+  switch (action.type) {
+    case "NAVIGATION":
+      return action.route;
+    default:
+      return state;
+  }
+};
+export default events;

--- a/src/reducers/route.test.js
+++ b/src/reducers/route.test.js
@@ -1,0 +1,22 @@
+// @flow
+import reducer from "./route";
+
+describe("Router reducer", () => {
+  it("initialises with default state", () => {
+    // $FlowFixMe
+    const state = reducer(undefined, {});
+
+    expect(state).toMatchSnapshot();
+  });
+
+  describe("NAVIGATION action", () => {
+    it("stores the current route", () => {
+      const state = reducer("", {
+        type: "NAVIGATION",
+        route: "somewhere"
+      });
+
+      expect(state).toMatchSnapshot();
+    });
+  });
+});

--- a/src/screens/CategoriesFilterScreen/component.js
+++ b/src/screens/CategoriesFilterScreen/component.js
@@ -15,9 +15,8 @@ import locale from "../../data/locale";
 export type Props = {
   navigation: NavigationScreenProp<NavigationState>,
   events: Event[],
-  stagedCategories: Set<EventCategoryName>,
+  categories: Set<EventCategoryName>,
   toggleCategoryFilter: (Set<EventCategoryName>, string) => void,
-  onApplyFilters: () => void,
   onClearAll: () => void
 };
 
@@ -27,32 +26,29 @@ class CategoriesFilterScreen extends PureComponent<Props> {
   };
 
   applyFilters = () => {
-    this.props.onApplyFilters();
-    this.props.navigation.pop();
+    this.props.navigation.goBack();
   };
 
   handleFilterChange = (categoryLabel: string) => {
-    this.props.toggleCategoryFilter(this.props.stagedCategories, categoryLabel);
+    this.props.toggleCategoryFilter(this.props.categories, categoryLabel);
   };
 
   render() {
-    const { events, stagedCategories } = this.props;
+    const { events, categories } = this.props;
     const buttonLabel =
-      stagedCategories.size > 0
-        ? text.showEvents(events.length)
-        : text.showAllEvents;
+      categories.size > 0 ? text.showEvents(events.length) : text.showAllEvents;
 
     return (
       <SafeAreaView style={styles.container}>
         <Header
           onBack={this.applyFilters}
           onClearAll={this.handleClearAll}
-          selectedCategories={stagedCategories}
+          selectedCategories={categories}
         />
         <View style={styles.list}>
           <List
             locale={locale}
-            stagedCategories={stagedCategories}
+            stagedCategories={categories}
             onPress={this.handleFilterChange}
           />
         </View>

--- a/src/screens/CategoriesFilterScreen/component.test.js
+++ b/src/screens/CategoriesFilterScreen/component.test.js
@@ -24,12 +24,11 @@ describe("CategoriesFilterScreen Component", () => {
   ]: any);
 
   it("renders correctly", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set(["Music"]);
+    const categories: Set<EventCategoryName> = new Set(["Music"]);
 
     const component = render({
       events,
-      stagedCategories,
-      onApplyFilters: () => {},
+      categories,
       toggleCategoryFilter: () => {},
       onClearAll: () => {}
     });
@@ -38,12 +37,11 @@ describe("CategoriesFilterScreen Component", () => {
   });
 
   it("renders correctly with no categories selected", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set();
+    const categories: Set<EventCategoryName> = new Set();
 
     const component = render({
       events,
-      stagedCategories,
-      onApplyFilters: () => {},
+      categories,
       toggleCategoryFilter: () => {},
       onClearAll: () => {}
     });
@@ -51,38 +49,13 @@ describe("CategoriesFilterScreen Component", () => {
     expect(component).toMatchSnapshot();
   });
 
-  it("closes the view and applies filters on pressing back button", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set(["Music"]);
-    const applySpy = jest.fn();
-    const popSpy = jest.fn();
-    const nav: NavigationScreenProp<NavigationState> = ({
-      pop: popSpy
-    }: any);
-    const component = render({
-      events,
-      stagedCategories,
-      onApplyFilters: applySpy,
-      toggleCategoryFilter: () => {},
-      onClearAll: () => {},
-      navigation: nav
-    });
-
-    component
-      .find(Header)
-      .props()
-      .onBack();
-    expect(applySpy).toBeCalled();
-    expect(popSpy).toBeCalled();
-  });
-
   it("clears the selected categories on pressing 'Clear All'", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set(["Music"]);
+    const categories: Set<EventCategoryName> = new Set(["Music"]);
     const clearAllSpy = jest.fn();
 
     const component = render({
       events,
-      stagedCategories,
-      onApplyFilters: () => {},
+      categories,
       toggleCategoryFilter: () => {},
       onClearAll: clearAllSpy,
       onClose: () => {}
@@ -95,17 +68,15 @@ describe("CategoriesFilterScreen Component", () => {
     expect(clearAllSpy).toBeCalled();
   });
 
-  it("closes the view and applyies the filters", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set(["Music"]);
-    const applyFiltersSpy = jest.fn();
-    const popSpy = jest.fn();
+  it("goes back on button press", () => {
+    const categories: Set<EventCategoryName> = new Set(["Music"]);
+    const backSpy = jest.fn();
     const nav: NavigationScreenProp<NavigationState> = ({
-      pop: popSpy
+      goBack: backSpy
     }: any);
     const component = render({
       events,
-      stagedCategories,
-      onApplyFilters: applyFiltersSpy,
+      categories,
       toggleCategoryFilter: () => {},
       onClearAll: () => {},
       onClose: () => {},
@@ -116,18 +87,16 @@ describe("CategoriesFilterScreen Component", () => {
       .find(Button)
       .props()
       .onPress();
-    expect(applyFiltersSpy).toBeCalled();
-    expect(popSpy).toBeCalled();
+    expect(backSpy).toBeCalled();
   });
 
   it("updates the filters when selecting a category", () => {
-    const stagedCategories: Set<EventCategoryName> = new Set(["Music"]);
+    const categories: Set<EventCategoryName> = new Set(["Music"]);
     const toggleCategoryFilterSpy = jest.fn();
 
     const component = render({
       events,
-      stagedCategories,
-      onApplyFilters: () => {},
+      categories,
       toggleCategoryFilter: toggleCategoryFilterSpy,
       onClearAll: () => {},
       onClose: () => {}

--- a/src/screens/CategoriesFilterScreen/index.js
+++ b/src/screens/CategoriesFilterScreen/index.js
@@ -2,11 +2,7 @@
 import { connect } from "react-redux";
 import type { Connector, MapStateToProps } from "react-redux";
 import type { NavigationScreenProp } from "react-navigation";
-import {
-  stageEventFilters,
-  commitEventFilters,
-  clearStagedEventFilters
-} from "../../actions/event-filters";
+import { setEventFilters } from "../../actions/event-filters";
 import type { State } from "../../reducers";
 import { selectFilteredEvents } from "../../selectors/events";
 import Component from "./component";
@@ -20,18 +16,16 @@ type Props = ComponentProps & OwnProps;
 
 const mapStateToProps: MapStateToProps<State, OwnProps, *> = state => ({
   events: selectFilteredEvents(state, true),
-  stagedCategories: state.eventFilters.stagedFilters.categories
+  categories: state.eventFilters.selectedFilters.categories
 });
 
 const mapDispatchToProps = {
-  onApplyFilters: () => commitEventFilters(),
-  toggleCategoryFilter: (stagedCategories, categoryLabel) => {
-    const categories = new Set([...stagedCategories]);
+  toggleCategoryFilter: (originalCagegories, categoryLabel) => {
+    const categories = new Set(originalCagegories);
     if (!categories.delete(categoryLabel)) categories.add(categoryLabel);
-    return stageEventFilters({ categories });
+    return setEventFilters({ categories });
   },
-  onClearAll: () => stageEventFilters({ categories: new Set() }),
-  onClose: () => clearStagedEventFilters()
+  onClearAll: () => setEventFilters({ categories: new Set() })
 };
 
 const connector: Connector<OwnProps, Props> = connect(

--- a/src/screens/CategoriesFilterScreen/index.test.js
+++ b/src/screens/CategoriesFilterScreen/index.test.js
@@ -45,7 +45,7 @@ const initialState = {
 };
 
 describe("CategoriesFilterScreen Container", () => {
-  describe("dispatches stage filters action with categories payload", () => {
+  describe("dispatches set filters action with categories payload", () => {
     it("removes the selected category from the payload if it was already staged", () => {
       const store = mockStore(initialState);
       const output = shallow(
@@ -58,7 +58,7 @@ describe("CategoriesFilterScreen Container", () => {
 
       expect(actions).toEqual([
         {
-          type: "STAGE_EVENT_FILTERS",
+          type: "SET_EVENT_FILTERS",
           payload: {
             categories: new Set(["Dance"])
           }
@@ -78,39 +78,12 @@ describe("CategoriesFilterScreen Container", () => {
 
       expect(actions).toEqual([
         {
-          type: "STAGE_EVENT_FILTERS",
+          type: "SET_EVENT_FILTERS",
           payload: {
             categories: new Set(["Dance"])
           }
         }
       ]);
     });
-  });
-
-  it("dispatches commit filters action to apply filters", () => {
-    const store = mockStore(initialState);
-    const output = shallow(<Container store={store} navigation={navigation} />);
-
-    output.props().onApplyFilters();
-
-    const actions = store.getActions();
-
-    expect(actions).toEqual([{ type: "COMMIT_EVENT_FILTERS" }]);
-  });
-
-  it("dispatches commit filters action and goes back on pressing back", () => {
-    const store = mockStore(initialState);
-    const output = shallow(<Container store={store} navigation={navigation} />);
-
-    output
-      .dive()
-      .find("Header")
-      .props()
-      .onBack();
-
-    const actions = store.getActions();
-
-    expect(navigation.pop).toBeCalled();
-    expect(actions).toEqual([{ type: "COMMIT_EVENT_FILTERS" }]);
   });
 });

--- a/src/screens/EventsScreen/component.js
+++ b/src/screens/EventsScreen/component.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { PureComponent } from "react";
+import React, { Component } from "react";
 import { StyleSheet, View } from "react-native";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
 import type { SavedEvents, EventDays } from "../../data/event";
@@ -29,7 +29,9 @@ export type Props = {
   selectedCategories: Set<string>
 };
 
-class EventsScreen extends PureComponent<Props> {
+class EventsScreen extends Component<Props> {
+  shouldComponentUpdate = () => this.props.navigation.isFocused();
+
   handleFilterCategoriesPress = () => {
     this.props.navigation.navigate(EVENT_CATEGORIES_FILTER);
   };

--- a/src/screens/EventsScreen/index.js
+++ b/src/screens/EventsScreen/index.js
@@ -27,7 +27,8 @@ const mapStateToProps = state => ({
   loading: selectEventsLoading(state),
   refreshing: selectEventsRefreshing(state),
   getAssetSource: getAssetSource(id => selectAssetById(state, id)),
-  selectedCategories: state.eventFilters.selectedFilters.categories
+  selectedCategories: state.eventFilters.selectedFilters.categories,
+  route: state.currentRoute // not used directly, but triggers re-render on navigation
 });
 
 const mapDispatchToProps = {

--- a/src/screens/FilterScreen/component.js
+++ b/src/screens/FilterScreen/component.js
@@ -20,8 +20,7 @@ type Props = {
   eventFilters: FilterCollection,
   numEventsSelected: number,
   numTagFiltersSelected: number,
-  onChange: TagFilter => void,
-  onCancel: () => void
+  onChange: TagFilter => void
 };
 
 const toggleTagFilter = (
@@ -36,19 +35,6 @@ const toggleTagFilter = (
 };
 
 class FilterScreen extends PureComponent<Props> {
-  componentDidMount() {
-    const { navigation, onCancel } = this.props;
-    this.didBlurSubscription = navigation.addListener("willBlur", onCancel);
-  }
-
-  componentWillUnmount() {
-    this.didBlurSubscription.remove();
-  }
-
-  didBlurSubscription: {
-    remove: () => void
-  };
-
   clearTagFilters = () =>
     this.props.onChange(
       Object.keys(tags).reduce((acc, key) => ({ ...acc, [key]: new Set() }), {})

--- a/src/screens/FilterScreen/component.js
+++ b/src/screens/FilterScreen/component.js
@@ -21,7 +21,6 @@ type Props = {
   numEventsSelected: number,
   numTagFiltersSelected: number,
   onChange: TagFilter => void,
-  onApply: () => void,
   onCancel: () => void
 };
 
@@ -65,7 +64,6 @@ class FilterScreen extends PureComponent<Props> {
   };
 
   handleApplyButtonPress = () => {
-    this.props.onApply();
     this.props.navigation.goBack();
   };
 

--- a/src/screens/FilterScreen/component.test.js
+++ b/src/screens/FilterScreen/component.test.js
@@ -16,7 +16,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
       />
@@ -40,7 +39,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={() => {}}
         onCancel={onCancel}
         eventFilters={eventFilters}
       />
@@ -67,7 +65,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={onChange}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
       />
@@ -99,7 +96,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numEventsSelected={0}
@@ -123,7 +119,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numTagFiltersSelected={eventFilters.price.size}
@@ -148,7 +143,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numTagFiltersSelected={eventFilters.price.size}
@@ -173,7 +167,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={onChangeSpy}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numTagFiltersSelected={eventFilters.price.size}
@@ -199,7 +192,6 @@ describe("FilterScreen", () => {
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={onChangeSpy}
-        onApply={() => {}}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numTagFiltersSelected={eventFilters.price.size}
@@ -212,7 +204,7 @@ describe("FilterScreen", () => {
     expect(onChangeSpy).toHaveBeenCalledWith({ price: new Set() });
   });
 
-  it("calls on apply and goes back in navigation when apply button pressed", () => {
+  it("goes back in navigation when apply button pressed", () => {
     const navigation = {
       addListener: () => {},
       goBack: jest.fn()
@@ -220,13 +212,11 @@ describe("FilterScreen", () => {
     const eventFilters = {
       price: new Set(["free"])
     };
-    const onApplySpy = jest.fn();
     const output = shallow(
       <FilterScreen
         navigation={navigation}
         applyButtonText="Show 26 events"
         onChange={() => {}}
-        onApply={onApplySpy}
         onCancel={() => {}}
         eventFilters={eventFilters}
         numTagFiltersSelected={eventFilters.price.size}
@@ -236,7 +226,6 @@ describe("FilterScreen", () => {
 
     output.find("Button").simulate("Press");
 
-    expect(onApplySpy).toHaveBeenCalled();
     expect(navigation.goBack).toHaveBeenCalled();
   });
 });

--- a/src/screens/FilterScreen/component.test.js
+++ b/src/screens/FilterScreen/component.test.js
@@ -23,34 +23,6 @@ describe("FilterScreen", () => {
     expect(output).toMatchSnapshot();
   });
 
-  it("adds willBlur susbscription on mount", () => {
-    const removeListener = jest.fn();
-    const navigation = {
-      addListener: jest.fn(() => ({ remove: removeListener })),
-      setParams: () => {}
-    };
-    const eventFilters = {
-      price: new Set()
-    };
-    const onCancel = () => {};
-
-    const output = shallow(
-      <FilterScreen
-        navigation={navigation}
-        applyButtonText="Show 26 events"
-        onChange={() => {}}
-        onCancel={onCancel}
-        eventFilters={eventFilters}
-      />
-    );
-
-    expect(navigation.addListener).toHaveBeenCalledWith("willBlur", onCancel);
-
-    output.unmount();
-
-    expect(removeListener).toHaveBeenCalled();
-  });
-
   it("dispatches empty filters when 'Clear all' button is pressed", () => {
     const navigation = {
       addListener: () => {}

--- a/src/screens/FilterScreen/index.js
+++ b/src/screens/FilterScreen/index.js
@@ -3,8 +3,7 @@ import { connect } from "react-redux";
 import type { Connector } from "react-redux";
 import type { NavigationScreenProp } from "react-navigation";
 import {
-  stageEventFilters,
-  commitEventFilters,
+  setEventFilters,
   clearStagedEventFilters
 } from "../../actions/event-filters";
 import { selectFilteredEvents } from "../../selectors/events";
@@ -34,13 +33,12 @@ const mapStateToProps = state => {
     applyButtonText: text.filterPickerApply(events.length),
     numEventsSelected: events.length,
     numTagFiltersSelected: selectTagFilterSelectedCount(state, true),
-    eventFilters: state.eventFilters.stagedFilters
+    eventFilters: state.eventFilters.selectedFilters
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  onChange: tagFilter => dispatch(stageEventFilters(tagFilter)),
-  onApply: () => dispatch(commitEventFilters()),
+  onChange: tagFilter => dispatch(setEventFilters(tagFilter)),
   onCancel: () => dispatch(clearStagedEventFilters())
 });
 

--- a/src/screens/FilterScreen/index.js
+++ b/src/screens/FilterScreen/index.js
@@ -4,7 +4,7 @@ import type { Connector } from "react-redux";
 import type { NavigationScreenProp } from "react-navigation";
 import {
   setEventFilters,
-  clearStagedEventFilters
+  clearEventFilters
 } from "../../actions/event-filters";
 import { selectFilteredEvents } from "../../selectors/events";
 import { selectTagFilterSelectedCount } from "../../selectors/event-filters";
@@ -23,7 +23,6 @@ type Props = {
   numEventsSelected: number,
   numTagFiltersSelected: number,
   onChange: (tagFilter: TagFilter) => void,
-  onApply: () => void,
   onCancel: () => void
 } & OwnProps;
 
@@ -39,7 +38,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ({
   onChange: tagFilter => dispatch(setEventFilters(tagFilter)),
-  onCancel: () => dispatch(clearStagedEventFilters())
+  onCancel: () => dispatch(clearEventFilters())
 });
 
 const connector: Connector<OwnProps, Props> = connect(

--- a/src/selectors/event-filters.test.js
+++ b/src/selectors/event-filters.test.js
@@ -39,7 +39,8 @@ const buildState = (
     selectedFilters,
     stagedFilters
   },
-  savedEvents: new Set()
+  savedEvents: new Set(),
+  currentRoute: "fakeRoute"
 });
 
 export type BuildEventArguments = {


### PR DESCRIPTION
Fix #334.

Unfortunately, the react navigation event listeners don't seem to fire when using the gesture, so instead I made the filters truly live and added an optimisation, so that the filters screens are still responsive.

There is now a route reducer, which listens to the NAVIGATION action and puts the current route on state. This gives the EventsScreen the chance to re-render on navigation (which it didn't have before) and we can use the `navigation.isFocused()` API in `shouldComponentUpdate` to only re-render the listing when it's on screen.

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [x] Unit tests

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
