### PR TITLE
Sends Slack message when release build fails on either platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,9 @@ jobs:
                 bundle exec fastlane release \
                 submit:true \
                 apk_path:$APK_PATH \
-                upload_key:$PLAY_STORE_UPLOAD_KEY_PATH
+                upload_key:$PLAY_STORE_UPLOAD_KEY_PATH \
+                ci_build_num:$CIRCLE_BUILD_NUM \
+                slack_webhook:$SLACK_WEBHOOK
       - <<: *bugsnag-upload-sourcemaps-android
 
   alpha-ios:
@@ -440,7 +442,8 @@ jobs:
                 submit:true \
                 ci_build_num:$CIRCLE_BUILD_NUM \
                 release_stage:$RELEASE_STAGE \
-                bugsnag_api_key:$BUGSNAG_API_KEY
+                bugsnag_api_key:$BUGSNAG_API_KEY \
+                slack_webhook:$SLACK_WEBHOOK
       - <<: *bugsnag-upload-sourcemaps-ios
 
   e2e-ios:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -80,12 +80,16 @@ platform :android do
 
   desc "Build and deploy to Play Store"
   lane :release do |options|
-    build_release
-    if options[:submit]
-      deploy_play_store(
-        apk: options[:apk_path],
-        upload_key: options[:upload_key]
-      )
+    begin
+      build_release
+      if options[:submit]
+        deploy_play_store(
+          apk: options[:apk_path],
+          upload_key: options[:upload_key]
+        )
+      end
+    rescue => exception
+      notify_failure(exception, options[:webhook], options[:ci_build_num])
     end
   end
 
@@ -134,5 +138,26 @@ platform :android do
     commit_msg = sh("git log --format=%B -n 1 #{commit_sha}").strip
     notes = "#{git_branch}/#{commit_msg} on #{date} at #{time}"
     return notes
+  end
+
+  def notify_failure(exception, webhook, build_num)
+    slack(
+      message: 'Android release build failed!',
+      success: false,
+      slack_url: webhook,
+      attachment_properties: {
+        fields: [
+          {
+            title: "Build number",
+            value: build_num,
+          },
+          {
+            title: "Error message",
+            value: exception.to_s,
+            short: false
+          }
+        ]
+      }
+    )
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -141,23 +141,25 @@ platform :android do
   end
 
   def notify_failure(exception, webhook, build_num)
-    slack(
-      message: 'Android release build failed!',
-      success: false,
-      slack_url: webhook,
-      attachment_properties: {
-        fields: [
-          {
-            title: "Build number",
-            value: build_num,
-          },
-          {
-            title: "Error message",
-            value: exception.to_s,
-            short: false
-          }
-        ]
-      }
-    )
+    if defined?(webhook)
+      slack(
+        message: 'Android release build failed!',
+        success: false,
+        slack_url: webhook,
+        attachment_properties: {
+          fields: [
+            {
+              title: "Build number",
+              value: build_num,
+            },
+            {
+              title: "Error message",
+              value: exception.to_s,
+              short: false
+            }
+          ]
+        }
+      )
+    end
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -89,7 +89,7 @@ platform :android do
         )
       end
     rescue => exception
-      notify_failure(exception, options[:webhook], options[:ci_build_num])
+      notify_failure(exception, options[:slack_webhook], options[:ci_build_num])
     end
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -178,23 +178,23 @@ platform :ios do
   end
 
   desc "Add devices"
-    lane :devices do |options|
-      new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
-      register_devices(devices: new_devices)
-    match(
-      type: "development",
-      app_identifier: "org.prideinlondon.festival",
-      force_for_new_devices: true
-    )
-    match(
-      type: "adhoc",
-      app_identifier: "org.prideinlondon.festival.alpha",
-      force_for_new_devices: true
-    )
-    match(
-      type: "adhoc",
-      app_identifier: "org.prideinlondon.festival.beta",
-      force_for_new_devices: true
-    )
+  lane :devices do |options|
+    new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
+    register_devices(devices: new_devices)
+  match(
+    type: "development",
+    app_identifier: "org.prideinlondon.festival",
+    force_for_new_devices: true
+  )
+  match(
+    type: "adhoc",
+    app_identifier: "org.prideinlondon.festival.alpha",
+    force_for_new_devices: true
+  )
+  match(
+    type: "adhoc",
+    app_identifier: "org.prideinlondon.festival.beta",
+    force_for_new_devices: true
+  )
   end
 end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -112,7 +112,7 @@ platform :ios do
         )
       end
     rescue => exception
-      notify_failure(exception, options[:webhook], options[:ci_build_num])
+      notify_failure(exception, options[:slack_webhook], options[:ci_build_num])
     end
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -125,59 +125,59 @@ platform :ios do
     )
   end
 
-    desc "Upload to HockeyApp"
-    lane :deploy_hockey do |options|
-      hockey(
-        api_token: options[:api_token],
-        public_identifier: options[:app_id],
-        notes: options[:notes],
-        status: options[:status],
-        notify: options[:notify],
-        commit_sha: options[:commit_sha]
-      )
-    end
+  desc "Upload to HockeyApp"
+  lane :deploy_hockey do |options|
+    hockey(
+      api_token: options[:api_token],
+      public_identifier: options[:app_id],
+      notes: options[:notes],
+      status: options[:status],
+      notify: options[:notify],
+      commit_sha: options[:commit_sha]
+    )
+  end
 
-    desc "Upload to Beta by Fabric"
-    lane :deploy_fabric do |options|
-      crashlytics(
-        api_token: options[:api_token],
-        build_secret: options[:build_secret],
-        notes: options[:notes],
-        groups: options[:groups],
-        notifications: options[:notify]
-      )
-    end
+  desc "Upload to Beta by Fabric"
+  lane :deploy_fabric do |options|
+    crashlytics(
+      api_token: options[:api_token],
+      build_secret: options[:build_secret],
+      notes: options[:notes],
+      groups: options[:groups],
+      notifications: options[:notify]
+    )
+  end
 
-    def build_notes(commit_sha)
-      date = Time.now.strftime('%F')
-      time = Time.now.strftime('%T')
-      commit_msg = sh("git log --format=%B -n 1 #{commit_sha}").strip
-      notes = "#{git_branch}/#{commit_msg} on #{date} at #{time}"
-      return notes
-    end
+  def build_notes(commit_sha)
+    date = Time.now.strftime('%F')
+    time = Time.now.strftime('%T')
+    commit_msg = sh("git log --format=%B -n 1 #{commit_sha}").strip
+    notes = "#{git_branch}/#{commit_msg} on #{date} at #{time}"
+    return notes
+  end
 
-    def notify_failure(exception, webhook, build_num)
-      slack(
-        message: 'iOS release build failed!',
-        success: false,
-        slack_url: webhook,
-        attachment_properties: {
-          fields: [
-            {
-              title: "Build number",
-              value: build_num,
-            },
-            {
-              title: "Error message",
-              value: exception.to_s,
-              short: false
-            }
-          ]
-        }
-      )
-    end
+  def notify_failure(exception, webhook, build_num)
+    slack(
+      message: 'iOS release build failed!',
+      success: false,
+      slack_url: webhook,
+      attachment_properties: {
+        fields: [
+          {
+            title: "Build number",
+            value: build_num,
+          },
+          {
+            title: "Error message",
+            value: exception.to_s,
+            short: false
+          }
+        ]
+      }
+    )
+  end
 
-    desc "Add devices"
+  desc "Add devices"
     lane :devices do |options|
       new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
       register_devices(devices: new_devices)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -93,22 +93,26 @@ platform :ios do
 
   desc "Build and Deploy a release to iTunes Connect"
   lane :release do |options|
-    ensure_git_branch(branch: "master")
-    increment_build_number(build_number:options[:ci_build_num])
-    build(
-      match_type: "appstore",
-      export_method: "app-store",
-      configuration: "Release",
-      app_identifier: "org.prideinlondon.festival"
-    )
-    if options[:submit]
-      deploy_testflight
-      download_dsyms(version: get_version_number)
-      upload_symbols_to_bugsnag
-      send_build_to_bugsnag(
-        api_key: options[:bugsnag_api_key],
-        release_stage: options[:release_stage]
+    begin
+      ensure_git_branch(branch: "master")
+      increment_build_number(build_number:options[:ci_build_num])
+      build(
+        match_type: "appstore",
+        export_method: "app-store",
+        configuration: "Release",
+        app_identifier: "org.prideinlondon.festival"
       )
+      if options[:submit]
+        deploy_testflight
+        download_dsyms(version: get_version_number)
+        upload_symbols_to_bugsnag
+        send_build_to_bugsnag(
+          api_key: options[:bugsnag_api_key],
+          release_stage: options[:release_stage]
+        )
+      end
+    rescue => exception
+      notify_failure(exception, options[:webhook], options[:ci_build_num])
     end
   end
 
@@ -121,41 +125,62 @@ platform :ios do
     )
   end
 
-  desc "Upload to HockeyApp"
-  lane :deploy_hockey do |options|
-    hockey(
-      api_token: options[:api_token],
-      public_identifier: options[:app_id],
-      notes: options[:notes],
-      status: options[:status],
-      notify: options[:notify],
-      commit_sha: options[:commit_sha]
-    )
-  end
+    desc "Upload to HockeyApp"
+    lane :deploy_hockey do |options|
+      hockey(
+        api_token: options[:api_token],
+        public_identifier: options[:app_id],
+        notes: options[:notes],
+        status: options[:status],
+        notify: options[:notify],
+        commit_sha: options[:commit_sha]
+      )
+    end
 
-  desc "Upload to Beta by Fabric"
-  lane :deploy_fabric do |options|
-    crashlytics(
-      api_token: options[:api_token],
-      build_secret: options[:build_secret],
-      notes: options[:notes],
-      groups: options[:groups],
-      notifications: options[:notify]
-    )
-  end
+    desc "Upload to Beta by Fabric"
+    lane :deploy_fabric do |options|
+      crashlytics(
+        api_token: options[:api_token],
+        build_secret: options[:build_secret],
+        notes: options[:notes],
+        groups: options[:groups],
+        notifications: options[:notify]
+      )
+    end
 
-  def build_notes(commit_sha)
-    date = Time.now.strftime('%F')
-    time = Time.now.strftime('%T')
-    commit_msg = sh("git log --format=%B -n 1 #{commit_sha}").strip
-    notes = "#{git_branch}/#{commit_msg} on #{date} at #{time}"
-    return notes
-  end
+    def build_notes(commit_sha)
+      date = Time.now.strftime('%F')
+      time = Time.now.strftime('%T')
+      commit_msg = sh("git log --format=%B -n 1 #{commit_sha}").strip
+      notes = "#{git_branch}/#{commit_msg} on #{date} at #{time}"
+      return notes
+    end
 
-  desc "Add devices"
-  lane :devices do |options|
-    new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
-    register_devices(devices: new_devices)
+    def notify_failure(exception, webhook, build_num)
+      slack(
+        message: 'iOS release build failed!',
+        success: false,
+        slack_url: webhook,
+        attachment_properties: {
+          fields: [
+            {
+              title: "Build number",
+              value: build_num,
+            },
+            {
+              title: "Error message",
+              value: exception.to_s,
+              short: false
+            }
+          ]
+        }
+      )
+    end
+
+    desc "Add devices"
+    lane :devices do |options|
+      new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
+      register_devices(devices: new_devices)
     match(
       type: "development",
       app_identifier: "org.prideinlondon.festival",

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -181,20 +181,20 @@ platform :ios do
   lane :devices do |options|
     new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id:'org.prideinlondon.festival', api_token:options[:api_token])
     register_devices(devices: new_devices)
-  match(
-    type: "development",
-    app_identifier: "org.prideinlondon.festival",
-    force_for_new_devices: true
-  )
-  match(
-    type: "adhoc",
-    app_identifier: "org.prideinlondon.festival.alpha",
-    force_for_new_devices: true
-  )
-  match(
-    type: "adhoc",
-    app_identifier: "org.prideinlondon.festival.beta",
-    force_for_new_devices: true
-  )
+    match(
+      type: "development",
+      app_identifier: "org.prideinlondon.festival",
+      force_for_new_devices: true
+    )
+    match(
+      type: "adhoc",
+      app_identifier: "org.prideinlondon.festival.alpha",
+      force_for_new_devices: true
+    )
+    match(
+      type: "adhoc",
+      app_identifier: "org.prideinlondon.festival.beta",
+      force_for_new_devices: true
+    )
   end
 end


### PR DESCRIPTION
If a CircleCI build fails we don't surface this other than the badge in our Readme.

When a release build fails then our CD is failing entirely so we need to know about it.

This PR adds a catch to the release builds inside fastlane so that when an exception is triggered during the build or upload to a store a message will be sent to #pride-devs slack channel