### PR TITLE
Fade previous days in calendar

### DIFF
--- a/src/components/DateRangePickerDay.js
+++ b/src/components/DateRangePickerDay.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import { View, TouchableWithoutFeedback, StyleSheet } from "react-native";
 import { equals } from "ramda";
-import { toFormat, FORMAT_WEEKDAY_MONTH_DAY } from "../lib/date";
+import { toFormat, now, isBefore, FORMAT_WEEKDAY_MONTH_DAY } from "../lib/date";
 
 import Text from "./Text";
 
@@ -100,6 +100,7 @@ export default class Day extends Component<DayProps> {
 
   render() {
     const { state, marking, date } = this.props;
+    const beforeToday = isBefore(date.dateString, now());
     const label = toFormat(date.dateString, FORMAT_WEEKDAY_MONTH_DAY);
     const traits = marking.selected ? ["button", "selected"] : ["button"];
 
@@ -111,7 +112,7 @@ export default class Day extends Component<DayProps> {
         accessibilityLabel={label}
         accessibilityComponentType="button"
       >
-        <View style={styles.container}>
+        <View style={[styles.container, beforeToday ? styles.faded : {}]}>
           {marking.selected && (
             <View style={styles.overlay}>
               <View style={leftFillerStyle(marking)} />
@@ -141,6 +142,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     alignSelf: "stretch"
+  },
+  faded: {
+    opacity: 0.5
   },
   overlay: {
     position: "absolute",

--- a/src/components/DateRangePickerDay.js
+++ b/src/components/DateRangePickerDay.js
@@ -2,7 +2,13 @@
 import React, { Component } from "react";
 import { View, TouchableWithoutFeedback, StyleSheet } from "react-native";
 import { equals } from "ramda";
-import { toFormat, now, isBefore, FORMAT_WEEKDAY_MONTH_DAY } from "../lib/date";
+import {
+  toFormat,
+  now,
+  isBefore,
+  isSameDay,
+  FORMAT_WEEKDAY_MONTH_DAY
+} from "../lib/date";
 
 import Text from "./Text";
 
@@ -100,7 +106,10 @@ export default class Day extends Component<DayProps> {
 
   render() {
     const { state, marking, date } = this.props;
-    const beforeToday = isBefore(date.dateString, now());
+    const dateNow = now();
+    const beforeToday =
+      isBefore(date.dateString, dateNow) &&
+      !isSameDay(date.dateString, dateNow);
     const label = toFormat(date.dateString, FORMAT_WEEKDAY_MONTH_DAY);
     const traits = marking.selected ? ["button", "selected"] : ["button"];
 

--- a/src/components/DateRangePickerDay.js
+++ b/src/components/DateRangePickerDay.js
@@ -117,9 +117,10 @@ export default class Day extends Component<DayProps> {
       <TouchableWithoutFeedback
         onPress={this.onPress}
         onLongPress={this.onLongPress}
-        accessibilityTraits={traits}
+        accessibilityTraits={beforeToday ? ["button", "disabled"] : traits}
         accessibilityLabel={label}
         accessibilityComponentType="button"
+        disabled={beforeToday}
       >
         <View style={[styles.container, beforeToday ? styles.faded : {}]}>
           {marking.selected && (

--- a/src/components/DateRangePickerDay.test.js
+++ b/src/components/DateRangePickerDay.test.js
@@ -80,7 +80,9 @@ describe("dateRangePickerDay", () => {
   });
 
   it("renders a faded day if before today", () => {
-    jest.spyOn(dateLib, "now").mockImplementation(() => "2018-08-13");
+    jest
+      .spyOn(dateLib, "now")
+      .mockImplementation(() => "2018-08-13T17:42:06+01:00");
 
     const output = render({
       date: date(2018, 7, 12),
@@ -89,6 +91,22 @@ describe("dateRangePickerDay", () => {
     });
 
     expect(output.children().props().style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ opacity: 0.5 })])
+    );
+  });
+
+  it("does not render a faded day if same day as today", () => {
+    jest
+      .spyOn(dateLib, "now")
+      .mockImplementation(() => "2018-08-12T17:42:06+01:00");
+
+    const output = render({
+      date: date(2018, 7, 12),
+      marking: {},
+      state: "disabled"
+    });
+
+    expect(output.children().props().style).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ opacity: 0.5 })])
     );
   });

--- a/src/components/DateRangePickerDay.test.js
+++ b/src/components/DateRangePickerDay.test.js
@@ -79,7 +79,7 @@ describe("dateRangePickerDay", () => {
     expect(output).toMatchSnapshot();
   });
 
-  it("renders a faded day if before today", () => {
+  it("renders a disabled day if before today", () => {
     jest
       .spyOn(dateLib, "now")
       .mockImplementation(() => "2018-08-13T17:42:06+01:00");
@@ -90,12 +90,14 @@ describe("dateRangePickerDay", () => {
       state: "disabled"
     });
 
+    expect(output.props().disabled).toEqual(true);
+    expect(output.props().accessibilityTraits).toContain("disabled");
     expect(output.children().props().style).toEqual(
       expect.arrayContaining([expect.objectContaining({ opacity: 0.5 })])
     );
   });
 
-  it("does not render a faded day if same day as today", () => {
+  it("does not render a disabled day if same day as today", () => {
     jest
       .spyOn(dateLib, "now")
       .mockImplementation(() => "2018-08-12T17:42:06+01:00");
@@ -106,6 +108,8 @@ describe("dateRangePickerDay", () => {
       state: "disabled"
     });
 
+    expect(output.props().disabled).toEqual(false);
+    expect(output.props().accessibilityTraits).not.toContain("disabled");
     expect(output.children().props().style).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ opacity: 0.5 })])
     );

--- a/src/components/DateRangePickerDay.test.js
+++ b/src/components/DateRangePickerDay.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import DateRangePickerDay from "./DateRangePickerDay";
+import * as dateLib from "../lib/date";
 
 const render = props =>
   shallow(
@@ -76,6 +77,20 @@ describe("dateRangePickerDay", () => {
     });
 
     expect(output).toMatchSnapshot();
+  });
+
+  it("renders a faded day if before today", () => {
+    jest.spyOn(dateLib, "now").mockImplementation(() => "2018-08-13");
+
+    const output = render({
+      date: date(2018, 7, 12),
+      marking: {},
+      state: "disabled"
+    });
+
+    expect(output.children().props().style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ opacity: 0.5 })])
+    );
   });
 
   describe("interaction", () => {

--- a/src/components/__snapshots__/DateRangePickerDay.test.js.snap
+++ b/src/components/__snapshots__/DateRangePickerDay.test.js.snap
@@ -10,6 +10,7 @@ exports[`dateRangePickerDay renders a beginning of a range 1`] = `
       "selected",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -117,6 +118,7 @@ exports[`dateRangePickerDay renders a beginning of a range 2`] = `
       "selected",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -223,6 +225,7 @@ exports[`dateRangePickerDay renders a disabled day 1`] = `
       "button",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -288,6 +291,7 @@ exports[`dateRangePickerDay renders a marked day 1`] = `
       "button",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -381,6 +385,7 @@ exports[`dateRangePickerDay renders a marked, selected day 1`] = `
       "selected",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -517,6 +522,7 @@ exports[`dateRangePickerDay renders a middle of a range 1`] = `
       "selected",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -624,6 +630,7 @@ exports[`dateRangePickerDay renders with a single selected day 1`] = `
       "selected",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >
@@ -730,6 +737,7 @@ exports[`dateRangePickerDay renders without date selection 1`] = `
       "button",
     ]
   }
+  disabled={false}
   onLongPress={[Function]}
   onPress={[Function]}
 >

--- a/src/components/__snapshots__/DateRangePickerDay.test.js.snap
+++ b/src/components/__snapshots__/DateRangePickerDay.test.js.snap
@@ -15,11 +15,14 @@ exports[`dateRangePickerDay renders a beginning of a range 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -119,11 +122,14 @@ exports[`dateRangePickerDay renders a beginning of a range 2`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -222,11 +228,14 @@ exports[`dateRangePickerDay renders a disabled day 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -284,11 +293,14 @@ exports[`dateRangePickerDay renders a marked day 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -374,11 +386,14 @@ exports[`dateRangePickerDay renders a marked, selected day 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -507,11 +522,14 @@ exports[`dateRangePickerDay renders a middle of a range 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -611,11 +629,14 @@ exports[`dateRangePickerDay renders with a single selected day 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component
@@ -714,11 +735,14 @@ exports[`dateRangePickerDay renders without date selection 1`] = `
 >
   <Component
     style={
-      Object {
-        "alignItems": "center",
-        "alignSelf": "stretch",
-        "flex": 1,
-      }
+      Array [
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "flex": 1,
+        },
+        Object {},
+      ]
     }
   >
     <Component

--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -26,7 +26,8 @@ export const toFormat = (date: string, format: string) =>
 
 export const isBefore = (d1: string, d2: string) => +parse(d1) < +parse(d2);
 
-export const now = () => DateTime.local().toISO(contentfulISOFormatOptions);
+export const now = () =>
+  LuxonDateTime.local().toISO(contentfulISOFormatOptions);
 
 export const addDays = (date: string, days: number) => add(date, { days });
 

--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -23,6 +23,8 @@ export const toFormat = (date: string, format: string) =>
 
 export const isBefore = (d1: string, d2: string) => +parse(d1) < +parse(d2);
 
+export const now = () => DateTime.local().toISO(contentfulISOFormatOptions);
+
 export const addDays = (date: string, days: number) => add(date, { days });
 
 export const isSameDay = (d1: string, d2: string) =>

--- a/src/lib/dates.test.js
+++ b/src/lib/dates.test.js
@@ -9,7 +9,8 @@ import {
   getHours,
   set,
   diff,
-  add
+  add,
+  now
 } from "./date";
 
 describe("toFormat", () => {
@@ -131,5 +132,11 @@ describe("add", () => {
     expect(add("2018-07-07T04:00+01:00", { days: 2, months: 1 })).toEqual(
       "2018-08-09T04:00+01:00"
     );
+  });
+});
+
+describe("now", () => {
+  it("returns current time as a string", () => {
+    expect(now()).toEqual(expect.any(String));
   });
 });


### PR DESCRIPTION
Fixes #146 

This PR makes calendar days compare their supplied date with the current day, and add an extra fade style if they are previous to today.

<img width="504" alt="screen shot 2018-05-30 at 18 14 36" src="https://user-images.githubusercontent.com/2011550/40736240-64519928-6435-11e8-9fa6-a4f671da1412.png">

## Pre-flight check-list

Before raising a pull request

* ~~Documentation~~
* [x] Unit tests

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [x] Galaxy S8 (Android 7.0/8.0)
  * [x] Galaxy S7 (Android 6.0)
  * [x] iPhone X (iOS 11.x)
  * [x] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [x] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings

![](https://thumbs.gfycat.com/FragrantHospitableDorado-size_restricted.gif)