### PR TITLE
Sponsor refactor

### DIFF
--- a/src/data/__snapshots__/field-ref.test.js.snap
+++ b/src/data/__snapshots__/field-ref.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldRef decoder correctly decodes valid CMS fielf reference 1`] = `
+Object {
+  "sys": Object {
+    "id": "test",
+  },
+}
+`;

--- a/src/data/__snapshots__/sponsor.test.js.snap
+++ b/src/data/__snapshots__/sponsor.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sponsor decoder correctly decodes valid CMS sponsor 1`] = `
+Object {
+  "contentType": "sponsor",
+  "fields": Object {
+    "sponsorLevel": "Headline",
+    "sponsorLogo": Object {
+      "id": "2o2SZPgYl2ABCWu2MoK333",
+    },
+    "sponsorName": "sponsorName",
+    "sponsorUrl": "sponsorUrl",
+  },
+  "id": "3O3SZPgYl2MUEWu2MoK2oi",
+  "locale": "en-GB",
+  "revision": 1,
+}
+`;

--- a/src/data/__snapshots__/sponsor.test.js.snap
+++ b/src/data/__snapshots__/sponsor.test.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sponsor decoder correctly decodes valid CMS sponsor 1`] = `
+exports[`Sponsor decoder correctly decodes valid CMS sponsor 1`] = `
 Object {
   "contentType": "sponsor",
   "fields": Object {
     "sponsorLevel": "Headline",
     "sponsorLogo": Object {
-      "id": "2o2SZPgYl2ABCWu2MoK333",
+      "sys": Object {
+        "id": "2o2SZPgYl2ABCWu2MoK333",
+      },
     },
     "sponsorName": "sponsorName",
     "sponsorUrl": "sponsorUrl",

--- a/src/data/field-ref.js
+++ b/src/data/field-ref.js
@@ -1,3 +1,12 @@
 // @flow
+import * as decode from "../lib/decode";
+import type { Decoder } from "../lib/decode";
 
 export type FieldRef = { sys: { id: string } };
+
+const decodeFieldRef: Decoder<FieldRef> = decode.map(
+  id => ({ sys: { id } }),
+  decode.at(["sys", "id"], decode.string)
+);
+
+export default decodeFieldRef;

--- a/src/data/field-ref.test.js
+++ b/src/data/field-ref.test.js
@@ -1,0 +1,27 @@
+// @flow
+import decodeFieldRef from "./field-ref";
+
+describe("FieldRef", () => {
+  describe("decoder", () => {
+    it("correctly decodes valid CMS fielf reference", () => {
+      const data: mixed = {
+        sys: {
+          id: "test"
+        }
+      };
+
+      const decoded = decodeFieldRef(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
+    it("fails if a property is missing", () => {
+      const data: mixed = {};
+
+      const decoded = decodeFieldRef(data);
+      expect(decoded.ok).toEqual(false);
+    });
+  });
+});

--- a/src/data/sponsor.js
+++ b/src/data/sponsor.js
@@ -1,16 +1,8 @@
 // @flow
 import * as decode from "../lib/decode";
 import type { Decoder } from "../lib/decode";
-
-// We will move this out as we move other content types to this pattern
-export type Reference = {
-  id: string
-};
-
-const referenceDecoder: Decoder<Reference> = decode.map(
-  id => ({ id }),
-  decode.at(["sys", "id"], decode.string)
-);
+import type { FieldRef } from "./field-ref";
+import decodeFieldRef from "./field-ref";
 
 export type SponsorLevel = "Headline" | "Gold" | "Silver" | "Bronze";
 
@@ -29,7 +21,7 @@ export type Sponsor = {
   revision: number,
   fields: {
     sponsorName: string,
-    sponsorLogo: Reference,
+    sponsorLogo: FieldRef,
     sponsorUrl: string,
     sponsorLevel: SponsorLevel
   }
@@ -48,7 +40,7 @@ const decodeSponsor = (locale: string): Decoder<Sponsor> =>
       "fields",
       decode.shape({
         sponsorName: decode.at(["sponsorName", locale], decode.string),
-        sponsorLogo: decode.at(["sponsorLogo", locale], referenceDecoder),
+        sponsorLogo: decode.at(["sponsorLogo", locale], decodeFieldRef),
         sponsorUrl: decode.at(["sponsorUrl", locale], decode.string),
         sponsorLevel: decode.at(["sponsorLevel", locale], sponsorLevelDecoder)
       })

--- a/src/data/sponsor.js
+++ b/src/data/sponsor.js
@@ -1,23 +1,58 @@
 // @flow
-import type { FieldRef } from "./field-ref";
+import * as decode from "../lib/decode";
+import type { Decoder } from "../lib/decode";
+
+// We will move this out as we move other content types to this pattern
+export type Reference = {
+  id: string
+};
+
+const referenceDecoder: Decoder<Reference> = decode.map(
+  id => ({ id }),
+  decode.at(["sys", "id"], decode.string)
+);
 
 export type SponsorLevel = "Headline" | "Gold" | "Silver" | "Bronze";
 
+const sponsorLevelDecoder: Decoder<SponsorLevel> = decode.oneOf([
+  decode.value("Headline"),
+  decode.value("Gold"),
+  decode.value("Silver"),
+  decode.value("Bronze")
+]);
+
 export type Sponsor = {
+  // important to keep this at the top level so type refinement works
+  contentType: "sponsor",
+  id: string,
+  locale: string,
+  revision: number,
   fields: {
-    sponsorName: { [string]: string },
-    sponsorLogo: { [string]: FieldRef },
-    sponsorUrl: { [string]: string },
-    sponsorLevel: { [string]: SponsorLevel }
-  },
-  sys: {
-    id: string,
-    type: string,
-    contentType: {
-      sys: {
-        id: "sponsor"
-      }
-    },
-    revision: number
+    sponsorName: string,
+    sponsorLogo: Reference,
+    sponsorUrl: string,
+    sponsorLevel: SponsorLevel
   }
 };
+
+const decodeSponsor = (locale: string): Decoder<Sponsor> =>
+  decode.shape({
+    contentType: decode.at(
+      ["sys", "contentType", "sys", "id"],
+      decode.value("sponsor")
+    ),
+    id: decode.at(["sys", "id"], decode.string),
+    locale: decode.succeed(locale),
+    revision: decode.at(["sys", "revision"], decode.number),
+    fields: decode.field(
+      "fields",
+      decode.shape({
+        sponsorName: decode.at(["sponsorName", locale], decode.string),
+        sponsorLogo: decode.at(["sponsorLogo", locale], referenceDecoder),
+        sponsorUrl: decode.at(["sponsorUrl", locale], decode.string),
+        sponsorLevel: decode.at(["sponsorLevel", locale], sponsorLevelDecoder)
+      })
+    )
+  });
+
+export default decodeSponsor;

--- a/src/data/sponsor.test.js
+++ b/src/data/sponsor.test.js
@@ -1,7 +1,7 @@
 // @flow
 import decodeSponsor from "./sponsor";
 
-describe("sponsor", () => {
+describe("Sponsor", () => {
   describe("decoder", () => {
     it("correctly decodes valid CMS sponsor", () => {
       const data: mixed = {

--- a/src/data/sponsor.test.js
+++ b/src/data/sponsor.test.js
@@ -1,0 +1,49 @@
+// @flow
+import decodeSponsor from "./sponsor";
+
+describe("sponsor", () => {
+  describe("decoder", () => {
+    it("correctly decodes valid CMS sponsor", () => {
+      const data: mixed = {
+        fields: {
+          sponsorName: { "en-GB": "sponsorName" },
+          sponsorLogo: { "en-GB": { sys: { id: "2o2SZPgYl2ABCWu2MoK333" } } },
+          sponsorUrl: { "en-GB": "sponsorUrl" },
+          sponsorLevel: { "en-GB": "Headline" }
+        },
+        sys: {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          contentType: {
+            sys: {
+              id: "sponsor"
+            }
+          },
+          revision: 1
+        }
+      };
+
+      const decoded = decodeSponsor("en-GB")(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
+    it("fails if a property is missing", () => {
+      const data: mixed = {
+        fields: {},
+        sys: {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          contentType: {
+            sys: {
+              id: "sponsor"
+            }
+          }
+        }
+      };
+
+      const decoded = decodeSponsor("en-GB")(data);
+      expect(decoded.ok).toEqual(false);
+    });
+  });
+});

--- a/src/integrations/cms.js
+++ b/src/integrations/cms.js
@@ -6,9 +6,8 @@ import { createClient } from "contentful/dist/contentful.browser.min";
 import { saveCmsData, loadCmsData } from "./storage";
 import type { Asset } from "../data/asset";
 import type { Event, FeaturedEvents } from "../data/event";
-import type { Sponsor } from "../data/sponsor";
 
-export type CmsEntry = Event | FeaturedEvents | Sponsor;
+export type CmsEntry = Event | FeaturedEvents;
 export type CmsData = {
   entries: CmsEntry[],
   deletedEntries: CmsEntry[],

--- a/src/lib/decode.js
+++ b/src/lib/decode.js
@@ -4,6 +4,8 @@ import { ok, error, map as mapResult } from "./result";
 
 // Decoders give you a way to safely convert from an unknown type to a
 // concrete type and recover from failure at runtime.
+// This is essentially a port of elm's JSON decoders
+// http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode
 export type Decoder<A> = mixed => Result<string, A>;
 
 export const succeed = <A>(v: A): Decoder<A> => () => ok(v);

--- a/src/lib/decode.test.js
+++ b/src/lib/decode.test.js
@@ -1,0 +1,355 @@
+// @flow
+import {
+  succeed,
+  string,
+  number,
+  value,
+  field,
+  at,
+  shape,
+  oneOf,
+  map,
+  filterMap
+} from "./decode";
+
+describe("succeed", () => {
+  it("creates a decoder that always succeeds", () => {
+    const input: mixed = "test";
+
+    const result = succeed(1)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual(1);
+    }
+  });
+});
+
+describe("string", () => {
+  it("succeeds when decoding string types", () => {
+    const input: mixed = "test";
+
+    const result = string(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("test");
+    }
+  });
+
+  it("fails when decoding non string types", () => {
+    const input: mixed = 1;
+
+    const result = string(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a string");
+    }
+  });
+});
+
+describe("number", () => {
+  it("succeeds at decoding number types", () => {
+    const input: mixed = 1;
+
+    const result = number(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual(1);
+    }
+  });
+
+  it("fails when decoding non number types", () => {
+    const input: mixed = "test";
+
+    const result = number(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a number");
+    }
+  });
+});
+
+describe("value", () => {
+  it("succeeds at decoding exact value", () => {
+    const input: mixed = 1;
+
+    const result = value(1)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual(1);
+    }
+  });
+
+  it("fails when decoding a different value", () => {
+    const input: mixed = "test";
+
+    const result = value(1)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not equal");
+    }
+  });
+});
+
+describe("field", () => {
+  it("succeeds at decoding a specific object field", () => {
+    const input: mixed = {
+      a: "test"
+    };
+
+    const result = field("a", string)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("test");
+    }
+  });
+
+  it("fails when input is not an object", () => {
+    const input: mixed = "test";
+
+    const result = field("a", string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not an object");
+    }
+  });
+
+  it("fails when object field is missing", () => {
+    const input: mixed = {};
+
+    const result = field("a", string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is missing field 'a'");
+    }
+  });
+
+  it("fails when object field is incorrect type", () => {
+    const input: mixed = {
+      a: 1
+    };
+
+    const result = field("a", string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a string");
+    }
+  });
+});
+
+describe("at", () => {
+  it("succeeds at decoding a deeply nested object field", () => {
+    const input: mixed = {
+      a: {
+        b: {
+          c: "test"
+        }
+      }
+    };
+
+    const result = at(["a", "b", "c"], string)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("test");
+    }
+  });
+
+  it("fails when deeply nested object field is missing", () => {
+    const input: mixed = {
+      a: {}
+    };
+
+    const result = at(["a", "b", "c"], string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is missing field 'b'");
+    }
+  });
+
+  it("fails when deeply nested object field is incorrect type", () => {
+    const input: mixed = {
+      a: {
+        b: {
+          c: 1
+        }
+      }
+    };
+
+    const result = at(["a", "b", "c"], string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a string");
+    }
+  });
+});
+
+describe("shape", () => {
+  it("returns an ok result when it succeeds", () => {
+    const decoder = shape({
+      a: field("a", string),
+      b: at(["b", "c"], number)
+    });
+
+    const result = decoder({
+      a: "A",
+      b: {
+        c: 2
+      }
+    });
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        a: "A",
+        b: 2
+      });
+    }
+  });
+
+  it("fails when input is not an object", () => {
+    const decoder = shape({
+      a: field("a", string),
+      b: at(["b", "c"], number)
+    });
+
+    const result = decoder("test");
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not an object");
+    }
+  });
+
+  it("fails if object is missing a key", () => {
+    const decoder = shape({
+      a: field("a", string),
+      b: at(["b", "c"], number)
+    });
+
+    const result = decoder({
+      a: "A"
+    });
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is missing field 'b'");
+    }
+  });
+
+  it("fails if a passed decoder fails", () => {
+    const decoder = shape({
+      a: field("a", string),
+      b: at(["b", "c"], number)
+    });
+
+    const result = decoder({
+      a: 1,
+      b: {
+        c: 2
+      }
+    });
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a string");
+    }
+  });
+});
+
+describe("oneOf", () => {
+  it("succeeds on the first successful decoder", () => {
+    const input: mixed = "value";
+
+    const result = oneOf([value("a"), value("b"), value("value")])(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("value");
+    }
+  });
+
+  it("fails if no decoders succeed", () => {
+    const input: mixed = "value";
+
+    const result = oneOf([value("a"), value("a"), value("c")])(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("no decoders matched");
+    }
+  });
+});
+
+describe("map", () => {
+  it("maps a successful decoder", () => {
+    const input: mixed = 1;
+
+    const result = map(v => v.toString(), number)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("1");
+    }
+  });
+
+  it("does not map a failed decoder", () => {
+    const input: mixed = "1";
+
+    const result = map(v => {
+      v.toString();
+    }, number)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not a number");
+    }
+  });
+});
+
+describe("filterMap", () => {
+  it("succeeds for an array", () => {
+    const input: mixed = ["a", 1, "b", 2];
+
+    const result = filterMap(string)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual(["a", "b"]);
+    }
+  });
+
+  it("succeeds with empty array if no valid valies in array", () => {
+    const input: mixed = [1, 2, 3];
+
+    const result = filterMap(string)(input);
+
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  it("fails if not passed an array", () => {
+    const input: mixed = "value";
+
+    const result = filterMap(string)(input);
+
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("value is not an array");
+    }
+  });
+});

--- a/src/lib/result.js
+++ b/src/lib/result.js
@@ -1,0 +1,29 @@
+// @flow
+
+// We might want to swap this out later for a generic result lib.
+// perhaps one that follows the fantasy-land spec.
+export type Result<X, A> = { ok: true, value: A } | { ok: false, error: X };
+
+export const ok = <X, A>(v: A): Result<X, A> => ({ ok: true, value: v });
+
+export const error = <X, A>(err: X): Result<X, A> => ({
+  ok: false,
+  error: err
+});
+
+export const map = <X, A, B>(
+  fn: (a: A) => B,
+  result: Result<X, A>
+): Result<X, B> => {
+  if (result.ok) {
+    return ok(fn(result.value));
+  }
+  return result;
+};
+
+export const withDefault = <X, A>(value: A, result: Result<X, A>) => {
+  if (result.ok) {
+    return result.value;
+  }
+  return value;
+};

--- a/src/lib/result.test.js
+++ b/src/lib/result.test.js
@@ -1,0 +1,52 @@
+// @flow
+import { ok, error, map, withDefault } from "./result";
+
+describe("ok", () => {
+  it("creates an ok result", () => {
+    const result = ok("test");
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual("test");
+    }
+  });
+});
+
+describe("error", () => {
+  it("creates an errored result", () => {
+    const result = error("message");
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("message");
+    }
+  });
+});
+
+describe("map", () => {
+  it("maps ok results", () => {
+    const result = map(value => value + 1, ok(1));
+    expect(result.ok).toEqual(true);
+    if (result.ok) {
+      expect(result.value).toEqual(2);
+    }
+  });
+
+  it("does not map errored results", () => {
+    const result = map(value => value + 1, error("message"));
+    expect(result.ok).toEqual(false);
+    if (!result.ok) {
+      expect(result.error).toEqual("message");
+    }
+  });
+});
+
+describe("withDefault", () => {
+  it("unwraps an ok result", () => {
+    const value = withDefault(2, ok(1));
+    expect(value).toEqual(1);
+  });
+
+  it("unwraps an error result with default value", () => {
+    const value = withDefault(2, error("message"));
+    expect(value).toEqual(2);
+  });
+});

--- a/src/reducers/__snapshots__/data.test.js.snap
+++ b/src/reducers/__snapshots__/data.test.js.snap
@@ -6,5 +6,6 @@ Object {
   "entries": Array [],
   "loading": true,
   "refreshing": false,
+  "sponsors": Array [],
 }
 `;

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -6,7 +6,7 @@ import type { Sponsor } from "../data/sponsor";
 import decodeSponsor from "../data/sponsor";
 import locale from "../data/locale";
 import type { Decoder } from "../lib/decode";
-import { filterMap as decodeFilerMap } from "../lib/decode";
+import { filterMap as decodeFilterMap } from "../lib/decode";
 import { withDefault as resultWithDefault } from "../lib/result";
 import { expandRecurringEventsInEntries } from "../selectors/events";
 
@@ -31,7 +31,7 @@ const processEntries = entries => expandRecurringEventsInEntries(entries);
 // moving locale here so we can deal with it in a single place
 // this can be moved inside the reducer function if we later want
 // to make this dynamic
-const decodeSponsors: Decoder<Array<Sponsor>> = decodeFilerMap(
+const decodeSponsors: Decoder<Array<Sponsor>> = decodeFilterMap(
   decodeSponsor(locale)
 );
 

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -1,13 +1,19 @@
 // @flow
-import type { Reducer } from "redux";
 import type { DataAction } from "../actions/data";
 import type { CmsEntry } from "../integrations/cms";
 import type { Asset } from "../data/asset";
+import type { Sponsor } from "../data/sponsor";
+import decodeSponsor from "../data/sponsor";
+import locale from "../data/locale";
+import type { Decoder } from "../lib/decode";
+import { filterMap as decodeFilerMap } from "../lib/decode";
+import { withDefault as resultWithDefault } from "../lib/result";
 import { expandRecurringEventsInEntries } from "../selectors/events";
 
 export type State = {
   entries: CmsEntry[],
   assets: Asset[],
+  sponsors: Sponsor[],
   loading: boolean,
   refreshing: boolean
 };
@@ -15,16 +21,21 @@ export type State = {
 const defaultState = {
   entries: [],
   assets: [],
+  sponsors: [],
   loading: true,
   refreshing: false
 };
 
 const processEntries = entries => expandRecurringEventsInEntries(entries);
 
-const reducer: Reducer<State, DataAction> = (
-  state: State = defaultState,
-  action: DataAction
-) => {
+// moving locale here so we can deal with it in a single place
+// this can be moved inside the reducer function if we later want
+// to make this dynamic
+const decodeSponsors: Decoder<Array<Sponsor>> = decodeFilerMap(
+  decodeSponsor(locale)
+);
+
+const reducer = (state: State = defaultState, action: DataAction) => {
   switch (action.type) {
     case "REQUEST_CMS_DATA":
       return {
@@ -43,7 +54,8 @@ const reducer: Reducer<State, DataAction> = (
         loading: false,
         refreshing: false,
         entries: processEntries(action.data.entries),
-        assets: action.data.assets
+        assets: action.data.assets,
+        sponsors: resultWithDefault([], decodeSponsors(action.data.entries))
       };
     default:
       return state;

--- a/src/reducers/data.test.js
+++ b/src/reducers/data.test.js
@@ -13,6 +13,7 @@ describe("Events reducer", () => {
     const initialState = {
       entries: [],
       assets: [],
+      sponsors: [],
       loading: false,
       refreshing: false
     };
@@ -26,6 +27,7 @@ describe("Events reducer", () => {
     const initialState = {
       entries: [],
       assets: [],
+      sponsors: [],
       loading: false,
       refreshing: false
     };
@@ -39,6 +41,7 @@ describe("Events reducer", () => {
     const initialState = {
       entries: [],
       assets: [],
+      sponsors: [],
       loading: true,
       refreshing: false
     };
@@ -51,6 +54,7 @@ describe("Events reducer", () => {
       ],
       assets: [{ sys: { id: "asset1", contentType: { sys: { id: "asset" } } } }]
     };
+
     // $FlowFixMe
     const state = reducer(initialState, {
       type: "RECEIVE_CMS_DATA",
@@ -67,6 +71,7 @@ describe("Events reducer", () => {
     const initialState = {
       entries: [],
       assets: [],
+      sponsors: [],
       loading: true,
       refreshing: false
     };
@@ -82,7 +87,9 @@ describe("Events reducer", () => {
           sys: { id: "event1", contentType: { sys: { id: "event" } } }
         }
       ],
-      assets: [{ id: "1" }]
+      assets: [{ id: "1" }],
+      syncToken: "abc",
+      updated: true
     };
     const expected = [
       {
@@ -105,6 +112,7 @@ describe("Events reducer", () => {
         }
       }
     ];
+
     // $FlowFixMe
     const state = reducer(initialState, {
       type: "RECEIVE_CMS_DATA",
@@ -115,5 +123,67 @@ describe("Events reducer", () => {
     expect(state.refreshing).toBe(false);
     expect(state.entries).toEqual(expected);
     expect(state.assets).toBe(newCmsData.assets);
+  });
+
+  describe("RECEIVE_CMS_DATA action", () => {
+    it("transforms sponsors", () => {
+      const initialState = {
+        entries: [],
+        assets: [],
+        sponsors: [],
+        loading: true,
+        refreshing: false
+      };
+
+      const newCmsData = {
+        entries: [
+          {
+            fields: {
+              sponsorName: { "en-GB": "sponsorName" },
+              sponsorLogo: {
+                "en-GB": { sys: { id: "2o2SZPgYl2ABCWu2MoK333" } }
+              },
+              sponsorUrl: { "en-GB": "sponsorUrl" },
+              sponsorLevel: { "en-GB": "Headline" }
+            },
+            sys: {
+              id: "3O3SZPgYl2MUEWu2MoK2oi",
+              contentType: {
+                sys: {
+                  id: "sponsor"
+                }
+              },
+              revision: 1
+            }
+          }
+        ],
+        assets: [],
+        syncToken: "abc",
+        updated: true
+      };
+
+      const expected = [
+        {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          contentType: "sponsor",
+          revision: 1,
+          locale: "en-GB",
+          fields: {
+            sponsorName: "sponsorName",
+            sponsorLogo: { id: "2o2SZPgYl2ABCWu2MoK333" },
+            sponsorUrl: "sponsorUrl",
+            sponsorLevel: "Headline"
+          }
+        }
+      ];
+
+      // $FlowFixMe
+      const state = reducer(initialState, {
+        type: "RECEIVE_CMS_DATA",
+        data: newCmsData
+      });
+
+      expect(state.sponsors).toEqual(expected);
+    });
   });
 });

--- a/src/reducers/data.test.js
+++ b/src/reducers/data.test.js
@@ -170,7 +170,7 @@ describe("Events reducer", () => {
           locale: "en-GB",
           fields: {
             sponsorName: "sponsorName",
-            sponsorLogo: { id: "2o2SZPgYl2ABCWu2MoK333" },
+            sponsorLogo: { sys: { id: "2o2SZPgYl2ABCWu2MoK333" } },
             sponsorUrl: "sponsorUrl",
             sponsorLevel: "Headline"
           }

--- a/src/screens/SponsorScreen/SponsorLogoContainer.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.js
@@ -11,13 +11,14 @@ import Text from "../../components/Text";
 import Touchable from "../../components/Touchable";
 import text from "../../constants/text";
 import { sponsorLogoBackgroundColor } from "../../constants/colors";
-import type { SponsorLevel, Sponsor, Reference } from "../../data/sponsor";
+import type { SponsorLevel, Sponsor } from "../../data/sponsor";
 import type { ImageSource } from "../../data/get-asset-source";
+import type { FieldRef } from "../../data/field-ref";
 
 type Props = {
   sponsorLevel: SponsorLevel,
   sponsors: Sponsor[],
-  getAssetSource: Reference => ImageSource,
+  getAssetSource: FieldRef => ImageSource,
   style?: ViewStyleProp
 };
 

--- a/src/screens/SponsorScreen/SponsorLogoContainer.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.js
@@ -11,16 +11,13 @@ import Text from "../../components/Text";
 import Touchable from "../../components/Touchable";
 import text from "../../constants/text";
 import { sponsorLogoBackgroundColor } from "../../constants/colors";
-import type { SponsorLevel, Sponsor } from "../../data/sponsor";
-import type { FieldRef } from "../../data/field-ref";
+import type { SponsorLevel, Sponsor, Reference } from "../../data/sponsor";
 import type { ImageSource } from "../../data/get-asset-source";
-
-import locale from "../../data/locale";
 
 type Props = {
   sponsorLevel: SponsorLevel,
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource,
+  getAssetSource: Reference => ImageSource,
   style?: ViewStyleProp
 };
 
@@ -49,7 +46,7 @@ const SponsorLogoContainer = ({
       {sponsors &&
         sponsors.map((sponsor, index) => (
           <View
-            key={sponsor.sys.id}
+            key={sponsor.id}
             style={
               sponsorLevel === "Headline" || sponsorLevel === "Gold"
                 ? [
@@ -64,14 +61,14 @@ const SponsorLogoContainer = ({
           >
             <Touchable
               style={styles.sponsorTile}
-              onPress={() => Linking.openURL(sponsor.fields.sponsorUrl[locale])}
+              onPress={() => Linking.openURL(sponsor.fields.sponsorUrl)}
               accessibilityTraits={["link"]}
-              testID={`sponsor-tile-${sponsor.sys.id}`}
+              testID={`sponsor-tile-${sponsor.id}`}
             >
               <SponsorLogo
-                sponsorName={sponsor.fields.sponsorName[locale]}
-                sponsorLevel={sponsor.fields.sponsorLevel[locale]}
-                sponsorLogo={getAssetSource(sponsor.fields.sponsorLogo[locale])}
+                sponsorName={sponsor.fields.sponsorName}
+                sponsorLevel={sponsor.fields.sponsorLevel}
+                sponsorLogo={getAssetSource(sponsor.fields.sponsorLogo)}
               />
             </Touchable>
           </View>

--- a/src/screens/SponsorScreen/SponsorLogoContainer.test.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.test.js
@@ -16,28 +16,19 @@ const generateSponsors = (count = 2): Sponsor[] =>
   Array.from(Array(count)).map(
     (_, i) =>
       ({
-        sys: {
-          id: String(i + 1)
-        },
+        contentType: "sponsor",
+        locale: "en-GB",
+        id: String(i + 1),
         fields: {
-          sponsorName: {
-            "en-GB": "some other"
-          },
+          sponsorName: "some other",
           sponsorLogo: {
-            "en-GB": {
-              sys: {
-                id: `asset${i + 1}`
-              }
-            }
+            id: `asset${i + 1}`
           },
-          sponsorUrl: {
-            "en-GB": "http://example.com"
-          },
-          sponsorLevel: {
-            "en-GB": "Gold"
-          }
-        }
-      }: any)
+          sponsorUrl: "http://example.com",
+          sponsorLevel: "Gold"
+        },
+        revision: 1
+      }: Sponsor)
   );
 
 const getAssetSource = jest.fn().mockReturnValue({

--- a/src/screens/SponsorScreen/SponsorLogoContainer.test.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.test.js
@@ -22,7 +22,7 @@ const generateSponsors = (count = 2): Sponsor[] =>
         fields: {
           sponsorName: "some other",
           sponsorLogo: {
-            id: `asset${i + 1}`
+            sys: { id: `asset${i + 1}` }
           },
           sponsorUrl: "http://example.com",
           sponsorLevel: "Gold"

--- a/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
@@ -73,7 +73,9 @@ exports[`SponsorScreen Component renders correctly 1`] = `
               "fields": Object {
                 "sponsorLevel": "Gold",
                 "sponsorLogo": Object {
-                  "id": "asset1",
+                  "sys": Object {
+                    "id": "asset1",
+                  },
                 },
                 "sponsorName": "Sponsor 1",
                 "sponsorUrl": "http://example.com",
@@ -87,7 +89,9 @@ exports[`SponsorScreen Component renders correctly 1`] = `
               "fields": Object {
                 "sponsorLevel": "Gold",
                 "sponsorLogo": Object {
-                  "id": "asset2",
+                  "sys": Object {
+                    "id": "asset2",
+                  },
                 },
                 "sponsorName": "Sponsor 2",
                 "sponsorUrl": "http://example.com",

--- a/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
@@ -69,50 +69,32 @@ exports[`SponsorScreen Component renders correctly 1`] = `
         sponsors={
           Array [
             Object {
+              "contentType": "sponsor",
               "fields": Object {
-                "sponsorLevel": Object {
-                  "en-GB": "Gold",
-                },
+                "sponsorLevel": "Gold",
                 "sponsorLogo": Object {
-                  "en-GB": Object {
-                    "sys": Object {
-                      "id": "asset1",
-                    },
-                  },
+                  "id": "asset1",
                 },
-                "sponsorName": Object {
-                  "en-GB": "Sponsor 1",
-                },
-                "sponsorUrl": Object {
-                  "en-GB": "http://example.com",
-                },
+                "sponsorName": "Sponsor 1",
+                "sponsorUrl": "http://example.com",
               },
-              "sys": Object {
-                "id": "1",
-              },
+              "id": "1",
+              "locale": "en-GB",
+              "revision": 1,
             },
             Object {
+              "contentType": "sponsor",
               "fields": Object {
-                "sponsorLevel": Object {
-                  "en-GB": "Gold",
-                },
+                "sponsorLevel": "Gold",
                 "sponsorLogo": Object {
-                  "en-GB": Object {
-                    "sys": Object {
-                      "id": "asset2",
-                    },
-                  },
+                  "id": "asset2",
                 },
-                "sponsorName": Object {
-                  "en-GB": "Sponsor 2",
-                },
-                "sponsorUrl": Object {
-                  "en-GB": "http://example.com",
-                },
+                "sponsorName": "Sponsor 2",
+                "sponsorUrl": "http://example.com",
               },
-              "sys": Object {
-                "id": "2",
-              },
+              "id": "2",
+              "locale": "en-GB",
+              "revision": 1,
             },
           ]
         }

--- a/src/screens/SponsorScreen/component.js
+++ b/src/screens/SponsorScreen/component.js
@@ -13,16 +13,13 @@ import ShadowedScrollView from "../../components/ShadowedScrollView";
 import SponsorLogoContainer from "./SponsorLogoContainer";
 import { whiteColor, lightNavyBlueColor } from "../../constants/colors";
 import text from "../../constants/text";
-import type { FieldRef } from "../../data/field-ref";
 import type { ImageSource } from "../../data/get-asset-source";
-import type { Sponsor } from "../../data/sponsor";
-
-import locale from "../../data/locale";
+import type { Sponsor, Reference } from "../../data/sponsor";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource
+  getAssetSource: Reference => ImageSource
 };
 
 class SponsorScreen extends PureComponent<Props> {
@@ -40,10 +37,10 @@ class SponsorScreen extends PureComponent<Props> {
     const { navigation, sponsors, getAssetSource } = this.props;
 
     const sortByName = R.sortBy(sponsor =>
-      sponsor.fields.sponsorName[locale].toLowerCase()
+      sponsor.fields.sponsorName.toLowerCase()
     );
     const groupSponsors = R.groupBy(
-      sponsor => sponsor.fields.sponsorLevel[locale],
+      sponsor => sponsor.fields.sponsorLevel,
       sortByName(sponsors)
     );
 

--- a/src/screens/SponsorScreen/component.js
+++ b/src/screens/SponsorScreen/component.js
@@ -14,12 +14,13 @@ import SponsorLogoContainer from "./SponsorLogoContainer";
 import { whiteColor, lightNavyBlueColor } from "../../constants/colors";
 import text from "../../constants/text";
 import type { ImageSource } from "../../data/get-asset-source";
-import type { Sponsor, Reference } from "../../data/sponsor";
+import type { Sponsor } from "../../data/sponsor";
+import type { FieldRef } from "../../data/field-ref";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,
   sponsors: Sponsor[],
-  getAssetSource: Reference => ImageSource
+  getAssetSource: FieldRef => ImageSource
 };
 
 class SponsorScreen extends PureComponent<Props> {

--- a/src/screens/SponsorScreen/component.test.js
+++ b/src/screens/SponsorScreen/component.test.js
@@ -22,7 +22,7 @@ const generateSponsors = (count = 2): Sponsor[] =>
           fields: {
             sponsorName: `Sponsor ${i + 1}`,
             sponsorLogo: {
-              id: `asset${i + 1}`
+              sys: { id: `asset${i + 1}` }
             },
             sponsorUrl: "http://example.com",
             sponsorLevel: "Gold"

--- a/src/screens/SponsorScreen/component.test.js
+++ b/src/screens/SponsorScreen/component.test.js
@@ -16,28 +16,19 @@ const generateSponsors = (count = 2): Sponsor[] =>
     .map(
       (_, i) =>
         ({
-          sys: {
-            id: String(i + 1)
-          },
+          contentType: "sponsor",
+          locale: "en-GB",
+          id: String(i + 1),
           fields: {
-            sponsorName: {
-              "en-GB": `Sponsor ${i + 1}`
-            },
+            sponsorName: `Sponsor ${i + 1}`,
             sponsorLogo: {
-              "en-GB": {
-                sys: {
-                  id: `asset${i + 1}`
-                }
-              }
+              id: `asset${i + 1}`
             },
-            sponsorUrl: {
-              "en-GB": "http://example.com"
-            },
-            sponsorLevel: {
-              "en-GB": "Gold"
-            }
-          }
-        }: any)
+            sponsorUrl: "http://example.com",
+            sponsorLevel: "Gold"
+          },
+          revision: 1
+        }: Sponsor)
     )
     .reverse();
 

--- a/src/screens/SponsorScreen/index.js
+++ b/src/screens/SponsorScreen/index.js
@@ -2,7 +2,8 @@
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
-import type { Sponsor, Reference } from "../../data/sponsor";
+import type { Sponsor } from "../../data/sponsor";
+import type { FieldRef } from "../../data/field-ref";
 import getAssetSource from "../../data/get-asset-source";
 import type { ImageSource } from "../../data/get-asset-source";
 import { selectAssetById } from "../../selectors/events";
@@ -15,7 +16,7 @@ type OwnProps = {
 
 type Props = {
   sponsors: Sponsor[],
-  getAssetSource: Reference => ImageSource
+  getAssetSource: FieldRef => ImageSource
 } & OwnProps;
 
 const mapStateToProps = state => ({

--- a/src/screens/SponsorScreen/index.js
+++ b/src/screens/SponsorScreen/index.js
@@ -19,9 +19,10 @@ type Props = {
   getAssetSource: FieldRef => ImageSource
 } & OwnProps;
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, { navigation }): Props => ({
   sponsors: selectSponsors(state),
-  getAssetSource: getAssetSource(id => selectAssetById(state, id))
+  getAssetSource: getAssetSource(id => selectAssetById(state, id)),
+  navigation
 });
 
 const mapDispatchToProps = {};

--- a/src/screens/SponsorScreen/index.js
+++ b/src/screens/SponsorScreen/index.js
@@ -2,8 +2,7 @@
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
-import type { Sponsor } from "../../data/sponsor";
-import type { FieldRef } from "../../data/field-ref";
+import type { Sponsor, Reference } from "../../data/sponsor";
 import getAssetSource from "../../data/get-asset-source";
 import type { ImageSource } from "../../data/get-asset-source";
 import { selectAssetById } from "../../selectors/events";
@@ -16,7 +15,7 @@ type OwnProps = {
 
 type Props = {
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource
+  getAssetSource: Reference => ImageSource
 } & OwnProps;
 
 const mapStateToProps = state => ({

--- a/src/selectors/event-filters.test.js
+++ b/src/selectors/event-filters.test.js
@@ -33,6 +33,7 @@ const buildState = (
   data: {
     entries: [],
     assets: [],
+    sponsors: [],
     loading: false,
     refreshing: false
   },

--- a/src/selectors/sponsors.js
+++ b/src/selectors/sponsors.js
@@ -2,10 +2,5 @@
 import type { State } from "../reducers";
 import type { Sponsor } from "../data/sponsor";
 
-const getDataState = (state: State) => state.data;
-
 /* eslint-disable import/prefer-default-export */
-export const selectSponsors = (state: State): Sponsor[] =>
-  ((getDataState(state).entries.filter(
-    entry => entry.sys.contentType.sys.id === "sponsor"
-  ): any[]): Sponsor[]);
+export const selectSponsors = (state: State): Sponsor[] => state.data.sponsors;

--- a/src/selectors/sponsors.test.js
+++ b/src/selectors/sponsors.test.js
@@ -4,16 +4,12 @@ describe("selectSponsors", () => {
   it("selects property", () => {
     const state = {
       data: {
-        entries: [
-          { sys: { contentType: { sys: { id: "event" } } } },
-          { sys: { contentType: { sys: { id: "sponsor" } } } }
-        ]
+        sponsors: []
       }
     };
 
     const selected = selectSponsors(state);
 
-    expect(selected.length).toBe(1);
-    expect(selected[0]).toBe(state.data.entries[1]);
+    expect(selected).toEqual(state.data.sponsors);
   });
 });


### PR DESCRIPTION
This PR is the first of a series I would like to make where we refactor towards safely decoding the CMS data into a completely type checked data model. Of note here is the use of a decoder to decode a Sponsor type into the Sponsor array in the data reducer.

Decoders allow us to compose transformation functions. These functions take in a `mixed` type and output a Result which is either ok, and has the concrete type on the value property, or is in an error state with an error message on the error property. In the case of the sponsor type:

```js
type SponsorDecoder = mixed => Result<string, Sponsor>
```

This encourages us to handle failure when decoding, in the sponsors case, defaulting to an empty array. (see `reducers/data.js`)

I have also taken this opportunity to simplify how we handle locale in the sponsor model. Having the type `{ [string]: Field }` is prone to error, as the property can be any string and even be missing. Instead, we hoist the locale during decoding so we no longer need to cater for it being missing.

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)
