### PR TITLE
Performance refactor

### DIFF
--- a/src/data/__snapshots__/performance.test.js.snap
+++ b/src/data/__snapshots__/performance.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Performance decoder correctly decodes valid CMS sponsor 1`] = `
+Object {
+  "contentType": "performance",
+  "fields": Object {
+    "startTime": "2018-08-18T17:55+00:00",
+    "title": "title",
+  },
+  "id": "m3w5",
+  "locale": "en-GB",
+  "revision": 1,
+}
+`;

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -2,9 +2,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { gen, sampleOne as sample } from "@rgbboy/testcheck";
 import type { ValueGenerator } from "@rgbboy/testcheck";
+import { DateTime } from "luxon";
+import { FORMAT_CONTENTFUL_ISO } from "../lib/date";
 import type { Event } from "./event";
 import type { FieldRef } from "./field-ref";
 import type { HeaderBanner } from "./header-banner";
+import type { Performance } from "./performance";
 import type { Sponsor } from "./sponsor";
 
 export const sampleOne = <A>(generator: ValueGenerator<A>): A =>
@@ -20,6 +23,15 @@ export const generateFieldRef: ValueGenerator<FieldRef> = gen({
     id: gen.alphaNumString
   })
 });
+
+const baseTime = 1530964800000; // July 7, 2018 12:00:00 PM GMT+00:00
+const fiveMinutes = 300000;
+
+export const generateDateString: ValueGenerator<string> = gen.int.then(int =>
+  DateTime.fromMillis(baseTime + int * int * int * fiveMinutes, {
+    zone: "UTC"
+  }).toFormat(FORMAT_CONTENTFUL_ISO)
+);
 
 // will change this when we refactor FieldRef
 export const generateCMSFieldRef: ValueGenerator<mixed> = generateFieldRef;
@@ -108,6 +120,37 @@ export const generateEvent: ValueGenerator<Event> = gen({
     eventsListPicture: gen({ "en-GB": generateFieldRef }),
     performances: { "en-GB": [] },
     recurrenceDates: { "en-GB": [] }
+  })
+});
+
+export const generatePerformance: ValueGenerator<Performance> = gen({
+  contentType: "performance",
+  id: gen.alphaNumString,
+  locale: "en-GB",
+  revision: 1,
+  fields: gen({
+    title: "title",
+    startTime: generateDateString
+  })
+});
+
+export const generateCMSPerformance: ValueGenerator<mixed> = gen({
+  sys: {
+    id: gen.alphaNumString,
+    contentType: {
+      sys: {
+        id: "performance"
+      }
+    },
+    revision: 1
+  },
+  fields: gen({
+    title: {
+      "en-GB": "title"
+    },
+    startTime: gen({
+      "en-GB": generateDateString
+    })
   })
 });
 

--- a/src/data/performance.js
+++ b/src/data/performance.js
@@ -1,0 +1,39 @@
+// @flow
+import * as decode from "../lib/decode";
+import type { Decoder } from "../lib/decode";
+
+export type Performances = {
+  [id: string]: Performance
+};
+
+export type Performance = {
+  // important to keep this at the top level so type refinement works
+  contentType: "performance",
+  id: string,
+  locale: string,
+  revision: number,
+  fields: {
+    title: string,
+    startTime: string
+  }
+};
+
+const decodePerformance = (locale: string): Decoder<Sponsor> =>
+  decode.shape({
+    contentType: decode.at(
+      ["sys", "contentType", "sys", "id"],
+      decode.value("performance")
+    ),
+    id: decode.at(["sys", "id"], decode.string),
+    locale: decode.succeed(locale),
+    revision: decode.at(["sys", "revision"], decode.number),
+    fields: decode.field(
+      "fields",
+      decode.shape({
+        title: decode.at(["title", locale], decode.string),
+        startTime: decode.at(["startTime", locale], decode.string)
+      })
+    )
+  });
+
+export default decodePerformance;

--- a/src/data/performance.test.js
+++ b/src/data/performance.test.js
@@ -1,0 +1,34 @@
+// @flow
+import { generateCMSPerformance, sampleOne } from "./__test-data";
+import decodePerformance from "./performance";
+
+describe("Performance", () => {
+  describe("decoder", () => {
+    it("correctly decodes valid CMS sponsor", () => {
+      const data: mixed = sampleOne(generateCMSPerformance);
+
+      const decoded = decodePerformance("en-GB")(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
+    it("fails if a property is missing", () => {
+      const data: mixed = {
+        fields: {},
+        sys: {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          contentType: {
+            sys: {
+              id: "performance"
+            }
+          }
+        }
+      };
+
+      const decoded = decodePerformance("en-GB")(data);
+      expect(decoded.ok).toEqual(false);
+    });
+  });
+});

--- a/src/selectors/performance.js
+++ b/src/selectors/performance.js
@@ -1,0 +1,11 @@
+// @flow
+import type { State } from "../reducers";
+import type { Performance, Performances } from "../data/performance";
+
+export const selectPerformances = (state: State): Performances =>
+  state.data.performances;
+
+export const selectPerformanceById = (
+  performances: Performances,
+  id: string
+): ?Performance => performances[id];

--- a/src/selectors/performance.test.js
+++ b/src/selectors/performance.test.js
@@ -1,0 +1,34 @@
+// @flow
+import { sampleOne, generatePerformance } from "../data/__test-data";
+import type { State } from "../reducers";
+import type { Performances } from "../data/performance";
+import { selectPerformances, selectPerformanceById } from "./performance";
+
+describe("selectPerformances", () => {
+  it("selects performances from state", () => {
+    // Will fix this along with the other fix me's once we have refactored
+    // @$FlowFixMe
+    const state: State = {
+      data: {
+        performances: {}
+      }
+    };
+
+    const selected = selectPerformances(state);
+
+    expect(selected).toEqual(state.data.performances);
+  });
+});
+
+describe("selectPerformanceById", () => {
+  it("selects performance", () => {
+    const performance = sampleOne(generatePerformance);
+    const performances: Performances = {
+      [performance.id]: performance
+    };
+
+    const selected = selectPerformanceById(performances, performance.id);
+
+    expect(selected).toEqual(performance);
+  });
+});


### PR DESCRIPTION
This PR applies the same pattern as established in #345 to the Performances. `state.data` now contains a dictionary of performances that are type safe 👍 