### PR TITLE
Asset refactor

### DIFF
--- a/src/data/__snapshots__/image.test.js.snap
+++ b/src/data/__snapshots__/image.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image decoder correctly decodes valid CMS image 1`] = `
+exports[`image decodeImageDetails correctly decodes valid CMS image 1`] = `
 Object {
   "height": 985,
   "id": "m3w5",

--- a/src/data/__snapshots__/image.test.js.snap
+++ b/src/data/__snapshots__/image.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Image decoder correctly decodes valid CMS image 1`] = `
+Object {
+  "height": 985,
+  "id": "m3w5",
+  "revision": 1,
+  "uri": "https://red-badger.com/BhabSLtI692l05Qliy85.jpg",
+  "width": 890,
+}
+`;

--- a/src/data/__snapshots__/performance.test.js.snap
+++ b/src/data/__snapshots__/performance.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Performance decoder correctly decodes valid CMS sponsor 1`] = `
+exports[`Performance decoder correctly decodes valid CMS performance 1`] = `
 Object {
   "contentType": "performance",
   "fields": Object {

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -33,8 +33,41 @@ export const generateDateString: ValueGenerator<string> = gen.int.then(int =>
   }).toFormat(FORMAT_CONTENTFUL_ISO)
 );
 
+export const generateImageURI: ValueGenerator<string> = gen.alphaNumString.then(
+  name => `//red-badger.com/${name}.jpg`
+);
+
 // will change this when we refactor FieldRef
 export const generateCMSFieldRef: ValueGenerator<mixed> = generateFieldRef;
+
+export const generateImage: ValueGenerator<Image> = gen({
+  id: gen.alphaNumString,
+  revision: 1,
+  uri: generateImageURI,
+  width: gen.intWithin(100, 1000),
+  height: gen.intWithin(100, 1000)
+});
+
+export const generateCMSImage: ValueGenerator<mixed> = gen({
+  sys: {
+    id: gen.alphaNumString,
+    type: "Asset",
+    revision: 1
+  },
+  fields: {
+    file: {
+      "en-GB": {
+        url: generateImageURI,
+        details: {
+          image: {
+            height: gen.intWithin(100, 1000),
+            width: gen.intWithin(100, 1000)
+          }
+        }
+      }
+    }
+  }
+});
 
 export const generateHeaderBanner: ValueGenerator<HeaderBanner> = gen({
   contentType: "headerBanner",

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -7,7 +7,7 @@ import { FORMAT_CONTENTFUL_ISO } from "../lib/date";
 import type { Event } from "./event";
 import type { FieldRef } from "./field-ref";
 import type { HeaderBanner } from "./header-banner";
-import type { Image } from "./image";
+import type { ImageDetails } from "./image";
 import type { Performance } from "./performance";
 import type { Sponsor } from "./sponsor";
 
@@ -41,7 +41,7 @@ export const generateImageURI: ValueGenerator<string> = gen.alphaNumString.then(
 // will change this when we refactor FieldRef
 export const generateCMSFieldRef: ValueGenerator<mixed> = generateFieldRef;
 
-export const generateImage: ValueGenerator<Image> = gen({
+export const generateImageDetails: ValueGenerator<ImageDetails> = gen({
   id: gen.alphaNumString,
   revision: 1,
   uri: generateImageURI,

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -7,6 +7,7 @@ import { FORMAT_CONTENTFUL_ISO } from "../lib/date";
 import type { Event } from "./event";
 import type { FieldRef } from "./field-ref";
 import type { HeaderBanner } from "./header-banner";
+import type { Image } from "./image";
 import type { Performance } from "./performance";
 import type { Sponsor } from "./sponsor";
 

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -1,0 +1,35 @@
+// @flow
+import * as decode from "../lib/decode";
+import type { Decoder } from "../lib/decode";
+
+export type Images = {
+  [id: string]: Image
+};
+
+export type Image = {
+  id: string,
+  revision: number,
+  uri: string,
+  width: number,
+  height: number
+};
+
+const decodeImage = (locale: string): Decoder<Image> =>
+  decode.shape({
+    id: decode.at(["sys", "id"], decode.string),
+    revision: decode.at(["sys", "revision"], decode.number),
+    uri: decode.map(
+      value => `https:${value}`,
+      decode.at(["fields", "file", locale, "url"], decode.string)
+    ),
+    height: decode.at(
+      ["fields", "file", locale, "details", "image", "height"],
+      decode.number
+    ),
+    width: decode.at(
+      ["fields", "file", locale, "details", "image", "width"],
+      decode.number
+    )
+  });
+
+export default decodeImage;

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -3,10 +3,10 @@ import * as decode from "../lib/decode";
 import type { Decoder } from "../lib/decode";
 
 export type Images = {
-  [id: string]: Image
+  [id: string]: ImageDetails
 };
 
-export type Image = {
+export type ImageDetails = {
   id: string,
   revision: number,
   uri: string,
@@ -14,7 +14,11 @@ export type Image = {
   height: number
 };
 
-const decodeImage = (locale: string): Decoder<Image> =>
+export const getImageDetails = (images: Images) => (
+  id: string
+): ?ImageDetails => images[id];
+
+export const decodeImageDetails = (locale: string): Decoder<ImageDetails> =>
   decode.shape({
     id: decode.at(["sys", "id"], decode.string),
     revision: decode.at(["sys", "revision"], decode.number),
@@ -31,5 +35,3 @@ const decodeImage = (locale: string): Decoder<Image> =>
       decode.number
     )
   });
-
-export default decodeImage;

--- a/src/data/image.test.js
+++ b/src/data/image.test.js
@@ -1,0 +1,29 @@
+// @flow
+import { generateCMSImage, sampleOne } from "./__test-data";
+import decodeImage from "./image";
+
+describe("Image", () => {
+  describe("decoder", () => {
+    it("correctly decodes valid CMS image", () => {
+      const data: mixed = sampleOne(generateCMSImage);
+
+      const decoded = decodeImage("en-GB")(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
+    it("fails if a property is missing", () => {
+      const data: mixed = {
+        fields: {},
+        sys: {
+          id: "3O3SZPgYl2MUEWu2MoK2oi"
+        }
+      };
+
+      const decoded = decodeImage("en-GB")(data);
+      expect(decoded.ok).toEqual(false);
+    });
+  });
+});

--- a/src/data/image.test.js
+++ b/src/data/image.test.js
@@ -1,13 +1,29 @@
 // @flow
-import { generateCMSImage, sampleOne } from "./__test-data";
-import decodeImage from "./image";
+import type { ImageDetails } from "./image";
+import {
+  generateImageDetails,
+  generateCMSImage,
+  sampleOne
+} from "./__test-data";
+import { decodeImageDetails, getImageDetails } from "./image";
 
-describe("Image", () => {
-  describe("decoder", () => {
+describe("image", () => {
+  describe("getImageDetails", () => {
+    it("returns the correct imageDetails", () => {
+      const imageDetails: ImageDetails = sampleOne(generateImageDetails);
+      const getter = getImageDetails({
+        [imageDetails.id]: imageDetails
+      });
+
+      expect(getter(imageDetails.id)).toEqual(imageDetails);
+    });
+  });
+
+  describe("decodeImageDetails", () => {
     it("correctly decodes valid CMS image", () => {
       const data: mixed = sampleOne(generateCMSImage);
 
-      const decoded = decodeImage("en-GB")(data);
+      const decoded = decodeImageDetails("en-GB")(data);
       expect(decoded.ok).toEqual(true);
       if (decoded.ok) {
         expect(decoded.value).toMatchSnapshot();
@@ -22,7 +38,7 @@ describe("Image", () => {
         }
       };
 
-      const decoded = decodeImage("en-GB")(data);
+      const decoded = decodeImageDetails("en-GB")(data);
       expect(decoded.ok).toEqual(false);
     });
   });

--- a/src/data/performance.test.js
+++ b/src/data/performance.test.js
@@ -4,7 +4,7 @@ import decodePerformance from "./performance";
 
 describe("Performance", () => {
   describe("decoder", () => {
-    it("correctly decodes valid CMS sponsor", () => {
+    it("correctly decodes valid CMS performance", () => {
       const data: mixed = sampleOne(generateCMSPerformance);
 
       const decoded = decodePerformance("en-GB")(data);

--- a/src/reducers/__snapshots__/data.test.js.snap
+++ b/src/reducers/__snapshots__/data.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "assets": Array [],
   "entries": Array [],
   "headerBanners": Array [],
+  "images": Object {},
   "loading": true,
   "performances": Object {},
   "refreshing": false,

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -7,7 +7,7 @@ import type { Images } from "../data/image";
 import type { Performances } from "../data/performance";
 import type { Sponsor } from "../data/sponsor";
 import decodeHeaderBanner from "../data/header-banner";
-import decodeImage from "../data/image";
+import { decodeImageDetails } from "../data/image";
 import decodePerformance from "../data/performance";
 import decodeSponsor from "../data/sponsor";
 import locale from "../data/locale";
@@ -61,7 +61,7 @@ const decodeHeaderBanners: Decoder<Array<HeaderBanner>> = decodeFilterMap(
 
 const decodeImages: Decoder<Images> = decodeMap(
   images => images.reduce(reduceToMapHelp, {}),
-  decodeFilterMap(decodeImage(locale))
+  decodeFilterMap(decodeImageDetails(locale))
 );
 
 const decodePerformances: Decoder<Performances> = decodeMap(

--- a/src/reducers/data.test.js
+++ b/src/reducers/data.test.js
@@ -14,6 +14,7 @@ describe("Events reducer", () => {
       entries: [],
       assets: [],
       headerBanners: [],
+      images: {},
       performances: {},
       sponsors: [],
       loading: false,
@@ -30,6 +31,7 @@ describe("Events reducer", () => {
       entries: [],
       assets: [],
       headerBanners: [],
+      images: {},
       performances: {},
       sponsors: [],
       loading: false,
@@ -46,6 +48,7 @@ describe("Events reducer", () => {
       entries: [],
       assets: [],
       headerBanners: [],
+      images: {},
       performances: {},
       sponsors: [],
       loading: true,
@@ -78,6 +81,7 @@ describe("Events reducer", () => {
       entries: [],
       assets: [],
       headerBanners: [],
+      images: {},
       performances: {},
       sponsors: [],
       loading: true,
@@ -138,6 +142,7 @@ describe("Events reducer", () => {
       entries: [],
       assets: [],
       headerBanners: [],
+      images: {},
       performances: {},
       sponsors: [],
       loading: true,
@@ -155,6 +160,7 @@ describe("Events reducer", () => {
         entries: [],
         assets: [],
         headerBanners: [],
+        images: {},
         performances: {},
         sponsors: [],
         loading: true,
@@ -217,6 +223,65 @@ describe("Events reducer", () => {
         entries: [],
         assets: [],
         headerBanners: [],
+        images: {},
+        performances: {},
+        sponsors: [],
+        loading: true,
+        refreshing: false
+      };
+
+      const newCmsData = {
+        entries: [],
+        assets: [
+          {
+            fields: {
+              file: {
+                "en-GB": {
+                  url: "//localhost/image.jpg",
+                  details: {
+                    image: {
+                      height: 100,
+                      width: 100
+                    }
+                  }
+                }
+              }
+            },
+            sys: {
+              id: "3O3SZPgYl2MUEWu2MoK2oi",
+              revision: 1
+            }
+          }
+        ],
+        syncToken: "abc",
+        updated: true
+      };
+
+      const expected = {
+        "3O3SZPgYl2MUEWu2MoK2oi": {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          revision: 1,
+          uri: "https://localhost/image.jpg",
+          width: 100,
+          height: 100
+        }
+      };
+
+      // $FlowFixMe
+      const state = reducer(initialState, {
+        type: "RECEIVE_CMS_DATA",
+        data: newCmsData
+      });
+
+      expect(state.images).toEqual(expected);
+    });
+
+    it("decodes performances", () => {
+      const initialState = {
+        entries: [],
+        assets: [],
+        headerBanners: [],
+        images: {},
         performances: {},
         sponsors: [],
         loading: true,
@@ -273,6 +338,7 @@ describe("Events reducer", () => {
         entries: [],
         assets: [],
         headerBanners: [],
+        images: {},
         performances: {},
         sponsors: [],
         loading: true,

--- a/src/screens/SponsorScreen/SponsorLogo.js
+++ b/src/screens/SponsorScreen/SponsorLogo.js
@@ -6,7 +6,7 @@ import type { ImageSource } from "../../data/get-asset-source";
 
 type Props = {
   sponsorName: string,
-  sponsorLogo: ImageSource,
+  sponsorLogo: ?ImageSource,
   sponsorLevel: SponsorLevel
 };
 

--- a/src/screens/SponsorScreen/SponsorLogo.js
+++ b/src/screens/SponsorScreen/SponsorLogo.js
@@ -2,11 +2,11 @@
 import React from "react";
 import { View, StyleSheet, Image } from "react-native";
 import type { SponsorLevel } from "../../data/sponsor";
-import type { ImageSource } from "../../data/get-asset-source";
+import type { ImageDetails } from "../../data/image";
 
 type Props = {
   sponsorName: string,
-  sponsorLogo: ?ImageSource,
+  sponsorLogo: ?ImageDetails,
   sponsorLevel: SponsorLevel
 };
 

--- a/src/screens/SponsorScreen/SponsorLogo.test.js
+++ b/src/screens/SponsorScreen/SponsorLogo.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import { shallow } from "enzyme";
+import { sampleOne, generateImageDetails } from "../../data/__test-data";
 import SponsorLogo from "./SponsorLogo";
 
 describe("SponsorLogo Component", () => {
@@ -8,7 +9,7 @@ describe("SponsorLogo Component", () => {
     const output = shallow(
       <SponsorLogo
         sponsorName="sponsorName"
-        sponsorLogo={{ uri: "sponsorLogoUrl", width: 100, height: 100 }}
+        sponsorLogo={sampleOne(generateImageDetails)}
         sponsorLevel="Gold"
       />
     );
@@ -19,7 +20,7 @@ describe("SponsorLogo Component", () => {
     const output = shallow(
       <SponsorLogo
         sponsorName="sponsorName"
-        sponsorLogo={{ uri: "sponsorLogoUrl", width: 100, height: 100 }}
+        sponsorLogo={sampleOne(generateImageDetails)}
         sponsorLevel="Silver"
       />
     );

--- a/src/screens/SponsorScreen/SponsorLogoContainer.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.js
@@ -12,13 +12,12 @@ import Touchable from "../../components/Touchable";
 import text from "../../constants/text";
 import { sponsorLogoBackgroundColor } from "../../constants/colors";
 import type { SponsorLevel, Sponsor } from "../../data/sponsor";
-import type { ImageSource } from "../../data/get-asset-source";
-import type { FieldRef } from "../../data/field-ref";
+import type { ImageDetails } from "../../data/image";
 
 type Props = {
   sponsorLevel: SponsorLevel,
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource,
+  getImageDetails: string => ?ImageDetails,
   style?: ViewStyleProp
 };
 
@@ -31,7 +30,7 @@ const sponsorLevelIcons = {
 
 const SponsorLogoContainer = ({
   sponsorLevel,
-  getAssetSource,
+  getImageDetails,
   sponsors,
   style
 }: Props) => (
@@ -69,7 +68,7 @@ const SponsorLogoContainer = ({
               <SponsorLogo
                 sponsorName={sponsor.fields.sponsorName}
                 sponsorLevel={sponsor.fields.sponsorLevel}
-                sponsorLogo={getAssetSource(sponsor.fields.sponsorLogo)}
+                sponsorLogo={getImageDetails(sponsor.fields.sponsorLogo.sys.id)}
               />
             </Touchable>
           </View>

--- a/src/screens/SponsorScreen/SponsorLogoContainer.test.js
+++ b/src/screens/SponsorScreen/SponsorLogoContainer.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { Linking } from "react-native";
 import { shallow } from "enzyme";
+import { sampleOne, generateImageDetails } from "../../data/__test-data";
 import SponsorLogoContainer from "./SponsorLogoContainer";
 import type { Sponsor } from "../../data/sponsor";
 
@@ -31,11 +32,9 @@ const generateSponsors = (count = 2): Sponsor[] =>
       }: Sponsor)
   );
 
-const getAssetSource = jest.fn().mockReturnValue({
-  uri: "http://example.com/image.png",
-  width: 1,
-  height: 1
-});
+const getImageDetails = jest
+  .fn()
+  .mockReturnValue(sampleOne(generateImageDetails));
 
 describe("SponsorLogoContainer Component", () => {
   it("renders correctly with Gold Level", () => {
@@ -43,7 +42,7 @@ describe("SponsorLogoContainer Component", () => {
       <SponsorLogoContainer
         sponsorLevel="Gold"
         sponsors={generateSponsors(2)}
-        getAssetSource={getAssetSource}
+        getImageDetails={getImageDetails}
       />
     );
     expect(output).toMatchSnapshot();
@@ -54,7 +53,7 @@ describe("SponsorLogoContainer Component", () => {
       <SponsorLogoContainer
         sponsorLevel="Silver"
         sponsors={generateSponsors(2)}
-        getAssetSource={getAssetSource}
+        getImageDetails={getImageDetails}
       />
     );
     expect(output).toMatchSnapshot();
@@ -65,7 +64,7 @@ describe("SponsorLogoContainer Component", () => {
       <SponsorLogoContainer
         sponsorLevel="Silver"
         sponsors={generateSponsors(2)}
-        getAssetSource={getAssetSource}
+        getImageDetails={getImageDetails}
       />
     );
     const sponsorLink = output.find({ testID: "sponsor-tile-1" });

--- a/src/screens/SponsorScreen/__snapshots__/SponsorLogo.test.js.snap
+++ b/src/screens/SponsorScreen/__snapshots__/SponsorLogo.test.js.snap
@@ -14,9 +14,11 @@ exports[`SponsorLogo Component renders correctly with Gold Level 1`] = `
     resizeMode="contain"
     source={
       Object {
-        "height": 100,
-        "uri": "sponsorLogoUrl",
-        "width": 100,
+        "height": 357,
+        "id": "3CU8n6O760GJ80Wr7r",
+        "revision": 1,
+        "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+        "width": 891,
       }
     }
     style={
@@ -43,9 +45,11 @@ exports[`SponsorLogo Component renders correctly with Silver Level 1`] = `
     resizeMode="contain"
     source={
       Object {
-        "height": 100,
-        "uri": "sponsorLogoUrl",
-        "width": 100,
+        "height": 357,
+        "id": "3CU8n6O760GJ80Wr7r",
+        "revision": 1,
+        "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+        "width": 891,
       }
     }
     style={

--- a/src/screens/SponsorScreen/__snapshots__/SponsorLogoContainer.test.js.snap
+++ b/src/screens/SponsorScreen/__snapshots__/SponsorLogoContainer.test.js.snap
@@ -75,9 +75,11 @@ exports[`SponsorLogoContainer Component renders correctly with Gold Level 1`] = 
           sponsorLevel="Gold"
           sponsorLogo={
             Object {
-              "height": 1,
-              "uri": "http://example.com/image.png",
-              "width": 1,
+              "height": 357,
+              "id": "3CU8n6O760GJ80Wr7r",
+              "revision": 1,
+              "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+              "width": 891,
             }
           }
           sponsorName="some other"
@@ -120,9 +122,11 @@ exports[`SponsorLogoContainer Component renders correctly with Gold Level 1`] = 
           sponsorLevel="Gold"
           sponsorLogo={
             Object {
-              "height": 1,
-              "uri": "http://example.com/image.png",
-              "width": 1,
+              "height": 357,
+              "id": "3CU8n6O760GJ80Wr7r",
+              "revision": 1,
+              "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+              "width": 891,
             }
           }
           sponsorName="some other"
@@ -208,9 +212,11 @@ exports[`SponsorLogoContainer Component renders correctly with Silver Level 1`] 
           sponsorLevel="Gold"
           sponsorLogo={
             Object {
-              "height": 1,
-              "uri": "http://example.com/image.png",
-              "width": 1,
+              "height": 357,
+              "id": "3CU8n6O760GJ80Wr7r",
+              "revision": 1,
+              "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+              "width": 891,
             }
           }
           sponsorName="some other"
@@ -253,9 +259,11 @@ exports[`SponsorLogoContainer Component renders correctly with Silver Level 1`] 
           sponsorLevel="Gold"
           sponsorLogo={
             Object {
-              "height": 1,
-              "uri": "http://example.com/image.png",
-              "width": 1,
+              "height": 357,
+              "id": "3CU8n6O760GJ80Wr7r",
+              "revision": 1,
+              "uri": "//red-badger.com/G36Nw4N4Qb1HE305M0V.jpg",
+              "width": 891,
             }
           }
           sponsorName="some other"

--- a/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/SponsorScreen/__snapshots__/component.test.js.snap
@@ -55,7 +55,7 @@ exports[`SponsorScreen Component renders correctly 1`] = `
         A huge thank you to our main partners for their continued support.
       </Text>
       <SponsorLogoContainer
-        getAssetSource={[MockFunction]}
+        getImageDetails={[MockFunction]}
         sponsorLevel="Headline"
         style={
           Object {
@@ -64,7 +64,7 @@ exports[`SponsorScreen Component renders correctly 1`] = `
         }
       />
       <SponsorLogoContainer
-        getAssetSource={[MockFunction]}
+        getImageDetails={[MockFunction]}
         sponsorLevel="Gold"
         sponsors={
           Array [
@@ -109,7 +109,7 @@ exports[`SponsorScreen Component renders correctly 1`] = `
         }
       />
       <SponsorLogoContainer
-        getAssetSource={[MockFunction]}
+        getImageDetails={[MockFunction]}
         sponsorLevel="Silver"
         style={
           Object {
@@ -118,7 +118,7 @@ exports[`SponsorScreen Component renders correctly 1`] = `
         }
       />
       <SponsorLogoContainer
-        getAssetSource={[MockFunction]}
+        getImageDetails={[MockFunction]}
         sponsorLevel="Bronze"
         style={
           Object {

--- a/src/screens/SponsorScreen/component.js
+++ b/src/screens/SponsorScreen/component.js
@@ -13,14 +13,13 @@ import ShadowedScrollView from "../../components/ShadowedScrollView";
 import SponsorLogoContainer from "./SponsorLogoContainer";
 import { whiteColor, lightNavyBlueColor } from "../../constants/colors";
 import text from "../../constants/text";
-import type { ImageSource } from "../../data/get-asset-source";
+import type { ImageDetails } from "../../data/image";
 import type { Sponsor } from "../../data/sponsor";
-import type { FieldRef } from "../../data/field-ref";
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState>,
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource
+  getImageDetails: string => ?ImageDetails
 };
 
 class SponsorScreen extends PureComponent<Props> {
@@ -35,7 +34,7 @@ class SponsorScreen extends PureComponent<Props> {
   };
 
   render() {
-    const { navigation, sponsors, getAssetSource } = this.props;
+    const { navigation, sponsors, getImageDetails } = this.props;
 
     const sortByName = R.sortBy(sponsor =>
       sponsor.fields.sponsorName.toLowerCase()
@@ -66,25 +65,25 @@ class SponsorScreen extends PureComponent<Props> {
             <SponsorLogoContainer
               sponsorLevel="Headline"
               sponsors={groupSponsors.Headline}
-              getAssetSource={getAssetSource}
+              getImageDetails={getImageDetails}
               style={styles.sponsorLogoContainerSpacingSmall}
             />
             <SponsorLogoContainer
               sponsorLevel="Gold"
               sponsors={groupSponsors.Gold}
-              getAssetSource={getAssetSource}
+              getImageDetails={getImageDetails}
               style={styles.sponsorLogoContainerSpacingLarge}
             />
             <SponsorLogoContainer
               sponsorLevel="Silver"
               sponsors={groupSponsors.Silver}
-              getAssetSource={getAssetSource}
+              getImageDetails={getImageDetails}
               style={styles.sponsorLogoContainerSpacingLarge}
             />
             <SponsorLogoContainer
               sponsorLevel="Bronze"
               sponsors={groupSponsors.Bronze}
-              getAssetSource={getAssetSource}
+              getImageDetails={getImageDetails}
               style={styles.sponsorLogoContainerSpacingLarge}
             />
             <Text style={styles.sponsorMainHeading} type="h1">

--- a/src/screens/SponsorScreen/component.test.js
+++ b/src/screens/SponsorScreen/component.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { email } from "react-native-communications";
 import { shallow } from "enzyme";
+import { sampleOne, generateImageDetails } from "../../data/__test-data";
 import Component from "./component";
 import type { Sponsor } from "../../data/sponsor";
 import text from "../../constants/text";
@@ -32,11 +33,10 @@ const generateSponsors = (count = 2): Sponsor[] =>
     )
     .reverse();
 
-const getAssetSource = jest.fn().mockReturnValue({
-  uri: "http://example.com/image.png",
-  width: 1,
-  height: 1
-});
+const getImageDetails = jest
+  .fn()
+  .mockReturnValue(sampleOne(generateImageDetails));
+
 const navigation: any = {
   goBack: jest.fn()
 };
@@ -51,7 +51,7 @@ describe("SponsorScreen Component", () => {
       <Component
         navigation={navigation}
         sponsors={generateSponsors(2)}
-        getAssetSource={getAssetSource}
+        getImageDetails={getImageDetails}
         {...props}
       />
     );
@@ -85,6 +85,6 @@ describe("SponsorScreen Component", () => {
 });
 
 afterEach(() => {
-  getAssetSource.mockClear();
+  getImageDetails.mockClear();
   navigation.goBack.mockClear();
 });

--- a/src/screens/SponsorScreen/index.js
+++ b/src/screens/SponsorScreen/index.js
@@ -4,10 +4,8 @@ import type { Connector } from "react-redux";
 import type { NavigationScreenProp, NavigationState } from "react-navigation";
 import type { State } from "../../reducers";
 import type { Sponsor } from "../../data/sponsor";
-import type { FieldRef } from "../../data/field-ref";
-import getAssetSource from "../../data/get-asset-source";
-import type { ImageSource } from "../../data/get-asset-source";
-import { selectAssetById } from "../../selectors/events";
+import { getImageDetails } from "../../data/image";
+import type { ImageDetails } from "../../data/image";
 import { selectSponsors } from "../../selectors/sponsors";
 import Component from "./component";
 
@@ -17,7 +15,7 @@ type OwnProps = {
 
 type Props = {
   sponsors: Sponsor[],
-  getAssetSource: FieldRef => ImageSource
+  getImageDetails: string => ?ImageDetails
 } & OwnProps;
 
 // Note we must add a return type here for react-redux connect to work
@@ -25,7 +23,7 @@ type Props = {
 // not line up. See https://github.com/facebook/flow/issues/5343
 const mapStateToProps = (state: State, { navigation }: OwnProps): Props => ({
   sponsors: selectSponsors(state),
-  getAssetSource: getAssetSource(id => selectAssetById(state, id)),
+  getImageDetails: getImageDetails(state.data.images),
   navigation
 });
 

--- a/src/selectors/event-filters.test.js
+++ b/src/selectors/event-filters.test.js
@@ -34,6 +34,7 @@ const buildState = (
     entries: [],
     assets: [],
     headerBanners: [],
+    images: {},
     performances: {},
     sponsors: [],
     loading: false,


### PR DESCRIPTION
This PR applies the same pattern as established in #345 to the Assets (well just images, because that is the only asset we use). `state.data` now contains a dictionary of imageDetails that are type safe.

This doesn't completely hook images up with all our components, but instead tries it out with the SponsorScreen. Of note is the fact that we may not have details for an image, as documented in the getImageDetails function:

```js
export const getImageDetails = (images: Images) => (
  id: string
): ?ImageDetails => images[id];
```

At some point I think it would be a good idea to create our own Image component that falls back when these details are missing (could just have a grey background or similar).

Once other components are refactored, we can remove the assets array in state and remove the getAssetSource functionality.

Keen to hear any thoughts/objections.