### PR TITLE
disable haptic temporarily

### DIFF
--- a/src/components/SaveEventButton.js
+++ b/src/components/SaveEventButton.js
@@ -20,9 +20,10 @@ type State = {
 
 const triggerAnimation = (progress: Object, active: boolean) => {
   const value = active ? 1 : 0;
-  if (active) {
-    ReactNativeHapticFeedback.trigger("impactHeavy");
-  }
+  // Disabling vibration: https://github.com/redbadger/pride-london-app/issues/351
+  // if (active) {
+  //   ReactNativeHapticFeedback.trigger("impactHeavy");
+  // }
   Animated.timing(progress, {
     toValue: value,
     duration: value * 800,

--- a/src/components/SaveEventButton.js
+++ b/src/components/SaveEventButton.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import { Animated, Easing, StyleSheet } from "react-native";
-import ReactNativeHapticFeedback from "react-native-haptic-feedback";
+// import ReactNativeHapticFeedback from "react-native-haptic-feedback";
 import LottieView from "lottie-react-native";
 import Touchable from "./Touchable";
 import heartAnimationLight from "../../assets/animations/save-event-light.json";

--- a/src/components/SaveEventButton.test.js
+++ b/src/components/SaveEventButton.test.js
@@ -86,7 +86,7 @@ describe("update from inactive to active", () => {
       easing: Easing.linear,
       useNativeDriver: true
     });
-    expect(ReactNativeHapticFeedback.trigger).toBeCalledWith("impactHeavy");
+    // expect(ReactNativeHapticFeedback.trigger).toBeCalledWith("impactHeavy");
   });
 });
 

--- a/src/components/SaveEventButton.test.js
+++ b/src/components/SaveEventButton.test.js
@@ -86,6 +86,7 @@ describe("update from inactive to active", () => {
       easing: Easing.linear,
       useNativeDriver: true
     });
+    // Disabling vibration: https://github.com/redbadger/pride-london-app/issues/351
     // expect(ReactNativeHapticFeedback.trigger).toBeCalledWith("impactHeavy");
   });
 });


### PR DESCRIPTION
As a temporary "fix" for #351 this PR disables haptic feedback on tapping the save event button. Looking deeper into the issue, there is a delay in the event list components having their `getDerivedStateFromProps` static method being called causing this to happen. This may be from the changes to support animating unsaved events on the saved events screen or from the animation delay from the navigation library. Surprisingly the number of events in the list affects this.