### PR TITLE
Fix incorrect parade day

### DIFF
--- a/src/constants/text.js
+++ b/src/constants/text.js
@@ -142,7 +142,7 @@ export default {
   paradeInformationScreen: {
     headerTitle: "Parade Day - 7th July",
     pageHeading: "London Parade",
-    pageSubheading: "Sunday 7th July",
+    pageSubheading: "Saturday 7th July",
     pageDescription:
       "The Pride in London Parade provides a platform for every part of London’s LGBT+ community to raise awareness of LGBT+ issues and campaign for the freedoms that will allow us to live our lives on a genuinely equal footing. It gives us a chance to be visible and speak loudly to the rest of the world about what we have achieved, how far we have come and what is still needed.",
     stages: [

--- a/src/screens/ParadeInformationScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/ParadeInformationScreen/__snapshots__/component.test.js.snap
@@ -43,7 +43,7 @@ exports[`renders correctly 1`] = `
             markdownStyle={Object {}}
             type="h2"
           >
-            Sunday 7th July
+            Saturday 7th July
           </Text>
           <Text
             color="blackColor"


### PR DESCRIPTION
Fixes #412. The day on the Stages screen is incorrect.

> The date should read "Saturday 7th July"

Updated screenshot:

<img width="559" alt="screen shot 2018-06-11 at 09 21 25" src="https://user-images.githubusercontent.com/1566539/41220605-d3d9bf8c-6d59-11e8-8033-1070b7bd55f9.png">
