### PR TITLE
Fail when precheck finds any violations

### DIFF
--- a/ios/fastlane/Deliverfile
+++ b/ios/fastlane/Deliverfile
@@ -1,6 +1,7 @@
 app_identifier 'org.prideinlondon.festival'
 precheck_include_in_app_purchases(false)
 precheck_default_rule_level(level: :error)
+automatic_release(true)
 overwrite_screenshots(true)
 submit_for_review(true)
 submission_information({

--- a/ios/fastlane/Deliverfile
+++ b/ios/fastlane/Deliverfile
@@ -1,5 +1,5 @@
 app_identifier 'org.prideinlondon.festival'
-automatic_release(true)
+precheck_include_in_app_purchases(false)
 overwrite_screenshots(true)
 submit_for_review(true)
 submission_information({

--- a/ios/fastlane/Deliverfile
+++ b/ios/fastlane/Deliverfile
@@ -1,5 +1,6 @@
 app_identifier 'org.prideinlondon.festival'
 precheck_include_in_app_purchases(false)
+precheck_default_rule_level(level: :error)
 overwrite_screenshots(true)
 submit_for_review(true)
 submission_information({


### PR DESCRIPTION
No reason not to fail a deploy if there are obvious issues that will lead to rejection.

Also skip IAP processing as we don't have any.