### PR TITLE
Use local version of detox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,7 +483,7 @@ jobs:
       - <<: *yarn-dependencies-macos
       - <<: *save-yarn-cache-macos
       - <<: *generate-env-macos
-      - run: detox clean-framework-cache && detox build-framework-cache
+      - run: npx detox clean-framework-cache && npx detox build-framework-cache
       - run: yarn test:e2e:release
       - store_artifacts:
           path: /tmp/screenshots


### PR DESCRIPTION
e2e were failing with `detox not found`

Not sure what has caused this now. Looks like global npm packages are being installed in the wrong directory. This solves it for now but will look into best solution