### PR TITLE
Fix Events Listing: Filtering can break the events list

### DIFF
--- a/src/components/EventList.js
+++ b/src/components/EventList.js
@@ -9,7 +9,7 @@ import SectionHeader from "./SectionHeader";
 import { whiteColor } from "../constants/colors";
 import type { SavedEvents, Event, EventDays } from "../data/event";
 import {
-  toFormat as formatDate,
+  toLocalFormat as formatDate,
   FORMAT_WEEKDAY_DAY_MONTH,
   FORMAT_YEAR_MONTH_DAY
 } from "../lib/date";

--- a/src/components/EventTile.js
+++ b/src/components/EventTile.js
@@ -5,7 +5,7 @@ import ConnectedImageBackground from "../components/ImageBackground";
 import Text from "../components/Text";
 import CategoryPill from "./CategoryPill";
 import { imageBgColor, eventTileTextColor } from "../constants/colors";
-import { toFormat, FORMAT_SHORT_WEEKDAY_DAY_MONTH } from "../lib/date";
+import { toLocalFormat, FORMAT_SHORT_WEEKDAY_DAY_MONTH } from "../lib/date";
 import type { FieldRef } from "../data/field-ref";
 import type { EventCategoryName } from "../data/event";
 
@@ -31,7 +31,7 @@ const EventTile = ({ eventCategories, name, date, imageReference }: Props) => (
     </ConnectedImageBackground>
     <View style={styles.details}>
       <Text type="small" style={{ color: eventTileTextColor }}>
-        {toFormat(date, FORMAT_SHORT_WEEKDAY_DAY_MONTH)}
+        {toLocalFormat(date, FORMAT_SHORT_WEEKDAY_DAY_MONTH)}
       </Text>
       <Text
         type="h3"

--- a/src/components/__snapshots__/EventCard.test.js.snap
+++ b/src/components/__snapshots__/EventCard.test.js.snap
@@ -96,7 +96,7 @@ exports[`renders correctly 1`] = `
           markdownStyle={Object {}}
           type="small"
         >
-          12:12 – 13:12
+          11:12 – 12:12
         </Text>
         <Text
           color="lightNavyBlueColor"
@@ -228,7 +228,7 @@ exports[`renders correctly when the event is free 1`] = `
           markdownStyle={Object {}}
           type="small"
         >
-          12:12 – 13:12
+          11:12 – 12:12
         </Text>
         <Text
           color="lightNavyBlueColor"
@@ -360,7 +360,7 @@ exports[`renders correctly when there is a price range 1`] = `
           markdownStyle={Object {}}
           type="small"
         >
-          12:12 – 13:12
+          11:12 – 12:12
         </Text>
         <Text
           color="lightNavyBlueColor"
@@ -492,7 +492,7 @@ exports[`renders correctly when there is only one price 1`] = `
           markdownStyle={Object {}}
           type="small"
         >
-          12:12 – 13:12
+          11:12 – 12:12
         </Text>
         <Text
           color="lightNavyBlueColor"

--- a/src/data/formatters.js
+++ b/src/data/formatters.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {
-  toFormat as formatDate,
+  toLocalFormat as formatDate,
   FORMAT_DAY_MONTH,
   FORMAT_TIME_24
 } from "../lib/date";

--- a/src/lib/__snapshots__/dates.test.js.snap
+++ b/src/lib/__snapshots__/dates.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`toFormat formats a date with a given format string 1`] = `"YYYY-07-Jul 7, 2018"`;

--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -24,6 +24,13 @@ const parse = (date: string) => LuxonDateTime.fromISO(date, { setZone: true });
 export const toFormat = (date: string, format: string) =>
   parse(date).toFormat(format);
 
+export const toLocalFormat = (date: string, format: string) =>
+  // Note toLocal transforms the timezone and time but retains
+  // the UTC time. Essentially it keeps the same value
+  parse(date)
+    .toLocal()
+    .toFormat(format);
+
 export const isBefore = (d1: string, d2: string) => +parse(d1) < +parse(d2);
 
 export const now = () =>

--- a/src/lib/dates.test.js
+++ b/src/lib/dates.test.js
@@ -1,5 +1,6 @@
 import {
   toFormat,
+  toLocalFormat,
   isBefore,
   addDays,
   compareAsc,
@@ -10,12 +11,36 @@ import {
   set,
   diff,
   add,
-  now
+  now,
+  FORMAT_CONTENTFUL_ISO,
+  FORMAT_WEEKDAY_MONTH_DAY
 } from "./date";
 
 describe("toFormat", () => {
   it("formats a date with a given format string", () => {
-    expect(toFormat("2018-07-07T04:00+01:00", "YYYY-MM-DD")).toMatchSnapshot();
+    expect(
+      toFormat("2018-07-07T04:00+01:00", FORMAT_WEEKDAY_MONTH_DAY)
+    ).toEqual("Saturday, July 7");
+  });
+
+  it("preserves timezone", () => {
+    expect(toFormat("2018-07-07T04:00+14:00", FORMAT_CONTENTFUL_ISO)).toEqual(
+      "2018-07-07T04:00+14:00"
+    );
+  });
+});
+
+describe("toLocalFormat", () => {
+  it("formats a date with a given format string", () => {
+    expect(
+      toLocalFormat("2018-07-07T04:00+01:00", FORMAT_WEEKDAY_MONTH_DAY)
+    ).toEqual("Saturday, July 7");
+  });
+
+  it("converts to local timezone", () => {
+    expect(
+      toLocalFormat("2018-07-07T04:00+14:00", FORMAT_CONTENTFUL_ISO)
+    ).toEqual("2018-07-06T14:00+00:00");
   });
 });
 

--- a/src/screens/DateFilterScreen/DateRangePicker.js
+++ b/src/screens/DateFilterScreen/DateRangePicker.js
@@ -6,7 +6,7 @@ import type { DayMarkings, CalendarDay } from "./DateRangePickerDay";
 import type { DateRange } from "../../data/date-time";
 import { scaleFont } from "../../components/Text";
 import {
-  toFormat as formatDate,
+  toLocalFormat as formatDate,
   isBefore,
   addDays,
   FORMAT_YEAR_MONTH_DAY

--- a/src/screens/DateFilterScreen/DateRangePickerDay.js
+++ b/src/screens/DateFilterScreen/DateRangePickerDay.js
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { View, TouchableWithoutFeedback, StyleSheet } from "react-native";
 import { equals } from "ramda";
 import {
-  toFormat,
+  toLocalFormat,
   now,
   isBefore,
   isSameDay,
@@ -104,7 +104,7 @@ export default class Day extends Component<DayProps> {
     const disabled =
       isBefore(date.dateString, dateNow) &&
       !isSameDay(date.dateString, dateNow);
-    const label = toFormat(date.dateString, FORMAT_WEEKDAY_MONTH_DAY);
+    const label = toLocalFormat(date.dateString, FORMAT_WEEKDAY_MONTH_DAY);
     const traits = marking.selected ? ["button", "selected"] : ["button"];
 
     return (

--- a/src/screens/EventDetailsScreen/EventOverview.js
+++ b/src/screens/EventDetailsScreen/EventOverview.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import {
-  toFormat as formatDate,
+  toLocalFormat as formatDate,
   isSameDay,
   FORMAT_SHORT_WEEKDAY_DATE
 } from "../../lib/date";

--- a/src/screens/EventDetailsScreen/RecurrenceDates.js
+++ b/src/screens/EventDetailsScreen/RecurrenceDates.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { StyleSheet } from "react-native";
 import {
-  toFormat as formatDate,
+  toLocalFormat as formatDate,
   compareAsc as compareDateAsc,
   FORMAT_DAY_MONTH
 } from "../../lib/date";


### PR DESCRIPTION
Fixes #436.

So it turns out we were not respecting timezones when creating the ids for the event list groups. This along with some of our test data having obscure timezones would cause repeated keys being used. This PR updates user facing times to always be coerced to the local timezone (while still preserving the actual time, i.e. time from epoch). While this means users would see different times depending on their timezone settings, they would see the correct time relevant to their device clock. Happy to be challenged on this.

## Pre-merge check-list

* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)