### PR TITLE
Add parade group data to state

### DIFF
--- a/src/data/__snapshots__/parade-group.test.js.snap
+++ b/src/data/__snapshots__/parade-group.test.js.snap
@@ -21,8 +21,8 @@ Object {
   "contentType": "paradeGroup",
   "fields": Object {
     "facebookURL": null,
-    "name": "test",
-    "section": "Section A",
+    "name": "mm2T1WpGuu4k03kl04088fDh1B5V",
+    "section": "Section C",
     "twitterURL": null,
     "websiteURL": null,
   },

--- a/src/data/__snapshots__/parade-group.test.js.snap
+++ b/src/data/__snapshots__/parade-group.test.js.snap
@@ -15,3 +15,19 @@ Object {
   "revision": 1,
 }
 `;
+
+exports[`Parade Group decoder correctly decodes valid CMS Parade Group with missing optional fields 1`] = `
+Object {
+  "contentType": "paradeGroup",
+  "fields": Object {
+    "facebookURL": null,
+    "name": "test",
+    "section": "Section A",
+    "twitterURL": null,
+    "websiteURL": null,
+  },
+  "id": "jU1T9830fV3Bl3Z3fk7yktQp",
+  "locale": "en-GB",
+  "revision": 1,
+}
+`;

--- a/src/data/__snapshots__/parade-group.test.js.snap
+++ b/src/data/__snapshots__/parade-group.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Parade Group decoder correctly decodes valid CMS Parade Group 1`] = `
+Object {
+  "contentType": "paradeGroup",
+  "fields": Object {
+    "facebookURL": "https://red-badger.com/24f3tJ9kLEIsCL0O8y881NG4pjYP2",
+    "name": "BhabSLtI692l05Qliy85",
+    "section": "Section E",
+    "twitterURL": "https://red-badger.com/Lh09pJ3",
+    "websiteURL": null,
+  },
+  "id": "hG",
+  "locale": "en-GB",
+  "revision": 1,
+}
+`;

--- a/src/data/__snapshots__/parade-group.test.js.snap
+++ b/src/data/__snapshots__/parade-group.test.js.snap
@@ -4,11 +4,11 @@ exports[`Parade Group decoder correctly decodes valid CMS Parade Group 1`] = `
 Object {
   "contentType": "paradeGroup",
   "fields": Object {
-    "facebookURL": "https://red-badger.com/24f3tJ9kLEIsCL0O8y881NG4pjYP2",
+    "facebookUrl": "https://red-badger.com/24f3tJ9kLEIsCL0O8y881NG4pjYP2",
     "name": "BhabSLtI692l05Qliy85",
     "section": "Section E",
-    "twitterURL": "https://red-badger.com/Lh09pJ3",
-    "websiteURL": null,
+    "twitterUrl": "https://red-badger.com/Lh09pJ3",
+    "websiteUrl": null,
   },
   "id": "hG",
   "locale": "en-GB",
@@ -20,11 +20,11 @@ exports[`Parade Group decoder correctly decodes valid CMS Parade Group with miss
 Object {
   "contentType": "paradeGroup",
   "fields": Object {
-    "facebookURL": null,
+    "facebookUrl": null,
     "name": "mm2T1WpGuu4k03kl04088fDh1B5V",
     "section": "Section C",
-    "twitterURL": null,
-    "websiteURL": null,
+    "twitterUrl": null,
+    "websiteUrl": null,
   },
   "id": "jU1T9830fV3Bl3Z3fk7yktQp",
   "locale": "en-GB",

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -5,11 +5,13 @@ import type { ValueGenerator } from "@rgbboy/testcheck";
 import { DateTime } from "luxon";
 import { FORMAT_CONTENTFUL_ISO, FORMAT_EUROPEAN_DATE } from "../lib/date";
 import type { Maybe } from "../lib/maybe";
+import { some, none } from "../lib/maybe";
 import type { Event, EventCategoryName } from "./event";
 import type { FeaturedEvents } from "./featured-events";
 import type { FieldRef } from "./field-ref";
 import type { HeaderBanner } from "./header-banner";
 import type { ImageDetails } from "./image";
+import type { ParadeGroup } from "./parade-group";
 import type { Performance } from "./performance";
 import type { Sponsor } from "./sponsor";
 import { eventCategoryNames } from "./event";
@@ -37,6 +39,10 @@ export const sampleArrayOf = <A>(
 
 // In order for flow to trickle the types for gen.null we had to wrap it
 const generateNull = <A>(): ValueGenerator<Maybe<A>> => gen.null;
+
+const generateMaybe = <A>(
+  generator: ValueGenerator<A>
+): ValueGenerator<Maybe<A>> => gen.oneOf([none(), generator.then(some)]);
 
 export const generateFieldRef: ValueGenerator<FieldRef> = gen({
   sys: gen({
@@ -342,7 +348,7 @@ const paradeGroupSections = [
   "Section G"
 ];
 
-export const generateParadeGroup: ValueGenerator<Performance> = gen({
+export const generateParadeGroup: ValueGenerator<ParadeGroup> = gen({
   contentType: "paradeGroup",
   id: gen.alphaNumString.notEmpty(),
   locale: "en-GB",
@@ -350,9 +356,9 @@ export const generateParadeGroup: ValueGenerator<Performance> = gen({
   fields: gen({
     name: gen.alphaNumString.notEmpty(),
     section: gen.oneOf(paradeGroupSections),
-    facebookURL: gen.oneOf([gen.null, generateURL]),
-    twitterURL: gen.oneOf([gen.null, generateURL]),
-    websiteURL: gen.oneOf([gen.null, generateURL])
+    facebookURL: generateMaybe(generateURL),
+    twitterURL: generateMaybe(generateURL),
+    websiteURL: generateMaybe(generateURL)
   })
 });
 

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -356,9 +356,9 @@ export const generateParadeGroup: ValueGenerator<ParadeGroup> = gen({
   fields: gen({
     name: gen.alphaNumString.notEmpty(),
     section: gen.oneOf(paradeGroupSections),
-    facebookURL: generateMaybe(generateURL),
-    twitterURL: generateMaybe(generateURL),
-    websiteURL: generateMaybe(generateURL)
+    facebookUrl: generateMaybe(generateURL),
+    twitterUrl: generateMaybe(generateURL),
+    websiteUrl: generateMaybe(generateURL)
   })
 });
 
@@ -379,19 +379,19 @@ export const generateCMSParadeGroup: ValueGenerator<mixed> = gen({
     section: gen({
       "en-GB": gen.oneOf(paradeGroupSections)
     }),
-    facebookURL: gen.oneOf([
+    facebookUrl: gen.oneOf([
       gen.undefined,
       gen({
         "en-GB": generateURL
       })
     ]),
-    twitterURL: gen.oneOf([
+    twitterUrl: gen.oneOf([
       gen.undefined,
       gen({
         "en-GB": generateURL
       })
     ]),
-    websiteURL: gen.oneOf([
+    websiteUrl: gen.oneOf([
       gen.undefined,
       gen({
         "en-GB": generateURL

--- a/src/data/__test-data.js
+++ b/src/data/__test-data.js
@@ -59,6 +59,10 @@ export const generateDateString: ValueGenerator<string> = gen.int.then(int =>
   }).toFormat(FORMAT_CONTENTFUL_ISO)
 );
 
+export const generateURL: ValueGenerator<string> = gen.alphaNumString.then(
+  value => `https://red-badger.com/${value}`
+);
+
 export const generateImageURI: ValueGenerator<string> = gen.alphaNumString.then(
   name => `//red-badger.com/${name}.jpg`
 );
@@ -325,6 +329,68 @@ export const generateCMSEventMinimum: ValueGenerator<mixed> = gen({
     eventDescription: { "en-GB": "eventDescription" },
     individualEventPicture: gen({ "en-GB": generateFieldRef }),
     eventsListPicture: gen({ "en-GB": generateFieldRef })
+  })
+});
+
+const paradeGroupSections = [
+  "Section A",
+  "Section B",
+  "Section C",
+  "Section D",
+  "Section E",
+  "Section F",
+  "Section G"
+];
+
+export const generateParadeGroup: ValueGenerator<Performance> = gen({
+  contentType: "paradeGroup",
+  id: gen.alphaNumString.notEmpty(),
+  locale: "en-GB",
+  revision: 1,
+  fields: gen({
+    name: gen.alphaNumString.notEmpty(),
+    section: gen.oneOf(paradeGroupSections),
+    facebookURL: gen.oneOf([gen.null, generateURL]),
+    twitterURL: gen.oneOf([gen.null, generateURL]),
+    websiteURL: gen.oneOf([gen.null, generateURL])
+  })
+});
+
+export const generateCMSParadeGroup: ValueGenerator<mixed> = gen({
+  sys: {
+    id: gen.alphaNumString.notEmpty(),
+    contentType: {
+      sys: {
+        id: "paradeGroup"
+      }
+    },
+    revision: 1
+  },
+  fields: gen({
+    name: gen({
+      "en-GB": gen.alphaNumString.notEmpty()
+    }),
+    section: gen({
+      "en-GB": gen.oneOf(paradeGroupSections)
+    }),
+    facebookURL: gen.oneOf([
+      gen.undefined,
+      gen({
+        "en-GB": generateURL
+      })
+    ]),
+    twitterURL: gen.oneOf([
+      gen.undefined,
+      gen({
+        "en-GB": generateURL
+      })
+    ]),
+    websiteURL: gen.oneOf([
+      gen.undefined,
+      gen({
+        "en-GB": generateURL
+      })
+    ])
   })
 });
 

--- a/src/data/parade-group.js
+++ b/src/data/parade-group.js
@@ -12,9 +12,9 @@ export type ParadeGroup = {
   fields: {
     name: string,
     section: string,
-    facebookURL: Maybe<string>,
-    twitterURL: Maybe<string>,
-    websiteURL: Maybe<string>
+    facebookUrl: Maybe<string>,
+    twitterUrl: Maybe<string>,
+    websiteUrl: Maybe<string>
   }
 };
 
@@ -39,9 +39,9 @@ const decodeParadeGroup = (locale: string): Decoder<ParadeGroup> =>
       decode.shape({
         name: decode.at(["name", locale], decode.string),
         section: decode.at(["section", locale], decode.string),
-        facebookURL: maybeField(locale, "facebookURL", decode.string),
-        twitterURL: maybeField(locale, "twitterURL", decode.string),
-        websiteURL: maybeField(locale, "websiteURL", decode.string)
+        facebookUrl: maybeField(locale, "facebookUrl", decode.string),
+        twitterUrl: maybeField(locale, "twitterUrl", decode.string),
+        websiteUrl: maybeField(locale, "websiteUrl", decode.string)
       })
     )
   });

--- a/src/data/parade-group.js
+++ b/src/data/parade-group.js
@@ -1,0 +1,49 @@
+// @flow
+import * as decode from "../lib/decode";
+import type { Decoder } from "../lib/decode";
+import type { Maybe } from "../lib/maybe";
+
+export type ParadeGroup = {
+  // important to keep this at the top level so type refinement works
+  contentType: "paradeGroup",
+  id: string,
+  locale: string,
+  revision: number,
+  fields: {
+    name: string,
+    section: string,
+    facebookURL: Maybe<string>,
+    twitterURL: Maybe<string>,
+    websiteURL: Maybe<string>
+  }
+};
+
+const maybeField = <A>(
+  locale: string,
+  field: string,
+  decoder: Decoder<A>
+): Decoder<Maybe<A>> =>
+  decode.field(field, decode.maybe(decode.field(locale, decoder)));
+
+const decodeParadeGroup = (locale: string): Decoder<ParadeGroup> =>
+  decode.shape({
+    contentType: decode.at(
+      ["sys", "contentType", "sys", "id"],
+      decode.value("paradeGroup")
+    ),
+    id: decode.at(["sys", "id"], decode.string),
+    locale: decode.succeed(locale),
+    revision: decode.at(["sys", "revision"], decode.number),
+    fields: decode.field(
+      "fields",
+      decode.shape({
+        name: decode.at(["name", locale], decode.string),
+        section: decode.at(["section", locale], decode.string),
+        facebookURL: maybeField(locale, "facebookURL", decode.string),
+        twitterURL: maybeField(locale, "twitterURL", decode.string),
+        websiteURL: maybeField(locale, "websiteURL", decode.string)
+      })
+    )
+  });
+
+export default decodeParadeGroup;

--- a/src/data/parade-group.test.js
+++ b/src/data/parade-group.test.js
@@ -1,0 +1,34 @@
+// @flow
+import { generateCMSParadeGroup, sampleOne } from "./__test-data";
+import decodeParadeGroup from "./parade-group";
+
+describe("Parade Group", () => {
+  describe("decoder", () => {
+    it("correctly decodes valid CMS Parade Group", () => {
+      const data: mixed = sampleOne(generateCMSParadeGroup);
+
+      const decoded = decodeParadeGroup("en-GB")(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
+    it("fails if a property is missing", () => {
+      const data: mixed = {
+        fields: {},
+        sys: {
+          id: "3O3SZPgYl2MUEWu2MoK2oi",
+          contentType: {
+            sys: {
+              id: "paradeGroup"
+            }
+          }
+        }
+      };
+
+      const decoded = decodeParadeGroup("en-GB")(data);
+      expect(decoded.ok).toEqual(false);
+    });
+  });
+});

--- a/src/data/parade-group.test.js
+++ b/src/data/parade-group.test.js
@@ -14,7 +14,7 @@ describe("Parade Group", () => {
       }
     });
 
-    it.only("correctly decodes valid CMS Parade Group with missing optional fields", () => {
+    it("correctly decodes valid CMS Parade Group with missing optional fields", () => {
       const data: mixed = {
         sys: {
           id: "jU1T9830fV3Bl3Z3fk7yktQp",

--- a/src/data/parade-group.test.js
+++ b/src/data/parade-group.test.js
@@ -14,14 +14,24 @@ describe("Parade Group", () => {
       }
     });
 
-    it("correctly decodes valid CMS Parade Group with missing optional fields", () => {
-      const data: mixed = sampleOne(generateCMSParadeGroup, { seed: 1234 });
-      data.fields = {
-        name: {
-          "en-GB": "test"
+    it.only("correctly decodes valid CMS Parade Group with missing optional fields", () => {
+      const data: mixed = {
+        sys: {
+          id: "jU1T9830fV3Bl3Z3fk7yktQp",
+          contentType: {
+            sys: {
+              id: "paradeGroup"
+            }
+          },
+          revision: 1
         },
-        section: {
-          "en-GB": "Section A"
+        fields: {
+          name: {
+            "en-GB": "mm2T1WpGuu4k03kl04088fDh1B5V"
+          },
+          section: {
+            "en-GB": "Section C"
+          }
         }
       };
 

--- a/src/data/parade-group.test.js
+++ b/src/data/parade-group.test.js
@@ -14,6 +14,24 @@ describe("Parade Group", () => {
       }
     });
 
+    it("correctly decodes valid CMS Parade Group with missing optional fields", () => {
+      const data: mixed = sampleOne(generateCMSParadeGroup, { seed: 1234 });
+      data.fields = {
+        name: {
+          "en-GB": "test"
+        },
+        section: {
+          "en-GB": "Section A"
+        }
+      };
+
+      const decoded = decodeParadeGroup("en-GB")(data);
+      expect(decoded.ok).toEqual(true);
+      if (decoded.ok) {
+        expect(decoded.value).toMatchSnapshot();
+      }
+    });
+
     it("fails if a property is missing", () => {
       const data: mixed = {
         fields: {},

--- a/src/reducers/__snapshots__/data.test.js.snap
+++ b/src/reducers/__snapshots__/data.test.js.snap
@@ -486,6 +486,7 @@ Object {
   "headerBanners": Array [],
   "images": Object {},
   "loading": true,
+  "paradeGroups": Array [],
   "performances": Object {},
   "refreshing": false,
   "sponsors": Array [],

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -5,12 +5,14 @@ import type { Event } from "../data/event";
 import type { FeaturedEvents } from "../data/featured-events";
 import type { HeaderBanner } from "../data/header-banner";
 import type { Images } from "../data/image";
+import type { ParadeGroup } from "../data/parade-group";
 import type { Performances } from "../data/performance";
 import type { Sponsor } from "../data/sponsor";
 import { decodeEvent, expandRecurringEvents } from "../data/event";
 import decodeFeaturedEvents from "../data/featured-events";
 import decodeHeaderBanner from "../data/header-banner";
 import { decodeImageDetails } from "../data/image";
+import decodeParadeGroup from "../data/parade-group";
 import decodePerformance from "../data/performance";
 import decodeSponsor from "../data/sponsor";
 import locale from "../data/locale";
@@ -23,6 +25,7 @@ export type State = {
   featuredEvents: FeaturedEvents[],
   headerBanners: HeaderBanner[],
   images: Images,
+  paradeGroups: ParadeGroup[],
   performances: Performances,
   sponsors: Sponsor[],
   loading: boolean,
@@ -34,6 +37,7 @@ const defaultState = {
   featuredEvents: [],
   headerBanners: [],
   images: {},
+  paradeGroups: [],
   performances: {},
   sponsors: [],
   loading: true,
@@ -73,6 +77,10 @@ const decodeImages: Decoder<Images> = decodeMap(
   decodeFilterMap(decodeImageDetails(locale))
 );
 
+const decodeParadeGroups: Decoder<Array<ParadeGroup>> = decodeFilterMap(
+  decodeParadeGroup(locale)
+);
+
 const decodePerformances: Decoder<Performances> = decodeMap(
   performances => performances.reduce(reduceToMapHelp, {}),
   decodeFilterMap(decodePerformance(locale))
@@ -110,6 +118,10 @@ const reducer = (state: State = defaultState, action: DataAction) => {
           decodeHeaderBanners(action.data.entries)
         ),
         images: resultWithDefault({}, decodeImages(action.data.assets)),
+        paradeGroups: resultWithDefault(
+          [],
+          decodeParadeGroups(action.data.entries)
+        ),
         performances: resultWithDefault(
           {},
           decodePerformances(action.data.entries)

--- a/src/reducers/data.test.js
+++ b/src/reducers/data.test.js
@@ -1,6 +1,7 @@
 // @flow
 import {
   generateCMSEvent,
+  generateCMSParadeGroup,
   generateCMSSponsor,
   sampleOne
 } from "../data/__test-data";
@@ -20,6 +21,7 @@ describe("Events reducer", () => {
       featuredEvents: [],
       headerBanners: [],
       images: {},
+      paradeGroups: [],
       performances: {},
       sponsors: [],
       loading: false,
@@ -37,6 +39,7 @@ describe("Events reducer", () => {
       featuredEvents: [],
       headerBanners: [],
       images: {},
+      paradeGroups: [],
       performances: {},
       sponsors: [],
       loading: false,
@@ -54,6 +57,7 @@ describe("Events reducer", () => {
       featuredEvents: [],
       headerBanners: [],
       images: {},
+      paradeGroups: [],
       performances: {},
       sponsors: [],
       loading: true,
@@ -72,6 +76,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -100,6 +105,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -137,6 +143,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -194,6 +201,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -257,6 +265,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -309,12 +318,43 @@ describe("Events reducer", () => {
       expect(state.images).toEqual(expected);
     });
 
+    it("decodes parade groups", () => {
+      const initialState = {
+        events: [],
+        featuredEvents: [],
+        headerBanners: [],
+        images: {},
+        paradeGroups: [],
+        performances: {},
+        sponsors: [],
+        loading: true,
+        refreshing: false
+      };
+
+      const newCmsData = {
+        entries: [sampleOne(generateCMSParadeGroup, { seed: 6534 })],
+        assets: [],
+        syncToken: "abc",
+        updated: true
+      };
+
+      // $FlowFixMe
+      const state = reducer(initialState, {
+        type: "RECEIVE_CMS_DATA",
+        data: newCmsData
+      });
+
+      // $FlowFixMe
+      expect(state.paradeGroups[0].id).toEqual(newCmsData.entries[0].sys.id);
+    });
+
     it("decodes performances", () => {
       const initialState = {
         events: [],
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,
@@ -372,6 +412,7 @@ describe("Events reducer", () => {
         featuredEvents: [],
         headerBanners: [],
         images: {},
+        paradeGroups: [],
         performances: {},
         sponsors: [],
         loading: true,

--- a/src/selectors/data.test.js
+++ b/src/selectors/data.test.js
@@ -25,6 +25,7 @@ const createData = (): DataState => ({
   featuredEvents: [],
   headerBanners: [],
   images: {},
+  paradeGroups: [],
   performances: {},
   sponsors: [],
   loading: false,


### PR DESCRIPTION
First part of [Parade Day - View Parade Groups by section](https://trello.com/c/yt0j2E9r/152-june-parade-day-view-parade-groups-by-section). This PR adds decoding parade group data from contentful and making it available on the data object of our state. 

Next steps are to add feature flags to enable showing parade groups instead of the parade info screen, then implementing showing the parade groups.

While this change is not visible, here is a log of the state from the test contentful demonstrating the correctly decoded data:

```json
[
  {
    "contentType": "paradeGroup",
    "id": "2eyd4CiRsQYQECY2Ig26qc",
    "locale": "en-GB",
    "revision": 1,
    "fields": {
      "name": "Test Parade Group with minimum fields",
      "section": "Section A",
      "facebookUrl": null,
      "twitterUrl": null,
      "websiteUrl": null
    }
  },
  {
    "contentType": "paradeGroup",
    "id": "40TKsW3jcA6GgKS8oK46ca",
    "locale": "en-GB",
    "revision": 1,
    "fields": {
      "name": "Test Parade Group with all the fields",
      "section": "Section A",
      "facebookUrl": "https://red-badger.com",
      "twitterUrl": "https://red-badger.com",
      "websiteUrl": "https://red-badger.com"
    }
  }
]
```