### PR TITLE
Potential Fix for Android Crashing Maps

### DIFF
--- a/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
@@ -44,7 +44,7 @@ exports[`renders correctly 1`] = `
         "latitude": 51.5085,
         "latitudeDelta": 0.02,
         "longitude": -0.134192,
-        "longitudeDelta": 4.1e-8,
+        "longitudeDelta": 4e-8,
       }
     }
     style={

--- a/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not render map when not focused 1`] = `
+<Component
+  style={
+    Object {
+      "bottom": 0,
+      "flexDirection": "column",
+      "justifyContent": "flex-end",
+      "left": 0,
+      "position": "absolute",
+      "right": 0,
+      "top": 0,
+    }
+  }
+  testID="parade-map-screen"
+>
+  <LocationCard
+    image={1}
+    name="Come back soon"
+    text="We are currently adding the events to the map. Check back later!"
+  />
+</Component>
+`;
+
 exports[`renders correctly 1`] = `
 <Component
   style={
@@ -16,7 +39,7 @@ exports[`renders correctly 1`] = `
   testID="parade-map-screen"
 >
   <MapView
-    region={
+    initialRegion={
       Object {
         "latitude": 51.5085,
         "latitudeDelta": 0.02,

--- a/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/component.test.js.snap
@@ -44,9 +44,14 @@ exports[`renders correctly 1`] = `
         "latitude": 51.5085,
         "latitudeDelta": 0.02,
         "longitude": -0.134192,
-        "longitudeDelta": 4e-8,
+        "longitudeDelta": 0.02,
       }
     }
+    showsBuildings={false}
+    showsIndoors={false}
+    showsPointsOfInterest={false}
+    showsScale={false}
+    showsTraffic={false}
     style={
       Object {
         "bottom": 0,

--- a/src/screens/ParadeMapScreen/component.js
+++ b/src/screens/ParadeMapScreen/component.js
@@ -14,7 +14,7 @@ const renderMap = () => (
       latitude: 51.5085,
       longitude: -0.134192,
       latitudeDelta: 0.02,
-      longitudeDelta: 0.000000041
+      longitudeDelta: 0.00000004
     }}
   >
     <Polyline

--- a/src/screens/ParadeMapScreen/component.js
+++ b/src/screens/ParadeMapScreen/component.js
@@ -14,8 +14,13 @@ const renderMap = () => (
       latitude: 51.5085,
       longitude: -0.134192,
       latitudeDelta: 0.02,
-      longitudeDelta: 0.00000004
+      longitudeDelta: 0.02
     }}
+    showsPointsOfInterest={false}
+    showsScale={false}
+    showsBuildings={false}
+    showsTraffic={false}
+    showsIndoors={false}
   >
     <Polyline
       coordinates={paradeCoordinates}

--- a/src/screens/ParadeMapScreen/component.js
+++ b/src/screens/ParadeMapScreen/component.js
@@ -7,38 +7,46 @@ import { velvetColor } from "../../constants/colors";
 import Text, { scaleWithFont } from "../../components/Text";
 import LocationCard from "./LocationCard";
 
-const ParadeMapScreen = () => (
+const renderMap = () => (
+  <MapView
+    style={StyleSheet.absoluteFill}
+    initialRegion={{
+      latitude: 51.5085,
+      longitude: -0.134192,
+      latitudeDelta: 0.02,
+      longitudeDelta: 0.000000041
+    }}
+  >
+    <Polyline
+      coordinates={paradeCoordinates}
+      strokeWidth={5}
+      strokeColor={velvetColor}
+      lineJoin="bevel"
+    />
+    <Marker coordinate={{ longitude: -0.14223, latitude: 51.51616 }}>
+      <View style={styles.markerView}>
+        <Text type="xSmall" color="whiteColor">
+          A
+        </Text>
+      </View>
+    </Marker>
+    <Marker coordinate={{ longitude: -0.1265, latitude: 51.50499 }}>
+      <View style={styles.markerView}>
+        <Text type="xSmall" color="whiteColor">
+          B
+        </Text>
+      </View>
+    </Marker>
+  </MapView>
+);
+
+type Props = {
+  isFocused: boolean
+};
+
+const ParadeMapScreen = ({ isFocused }: Props) => (
   <View style={styles.container} testID="parade-map-screen">
-    <MapView
-      style={StyleSheet.absoluteFill}
-      region={{
-        latitude: 51.5085,
-        longitude: -0.134192,
-        latitudeDelta: 0.02,
-        longitudeDelta: 0.000000041
-      }}
-    >
-      <Polyline
-        coordinates={paradeCoordinates}
-        strokeWidth={5}
-        strokeColor={velvetColor}
-        lineJoin="bevel"
-      />
-      <Marker coordinate={{ longitude: -0.14223, latitude: 51.51616 }}>
-        <View style={styles.markerView}>
-          <Text type="xSmall" color="whiteColor">
-            A
-          </Text>
-        </View>
-      </Marker>
-      <Marker coordinate={{ longitude: -0.1265, latitude: 51.50499 }}>
-        <View style={styles.markerView}>
-          <Text type="xSmall" color="whiteColor">
-            B
-          </Text>
-        </View>
-      </Marker>
-    </MapView>
+    {isFocused ? renderMap() : null}
     <LocationCard />
   </View>
 );

--- a/src/screens/ParadeMapScreen/component.test.js
+++ b/src/screens/ParadeMapScreen/component.test.js
@@ -9,6 +9,6 @@ it("renders correctly", () => {
 });
 
 it("does not render map when not focused", () => {
-  const output = shallow(<ParadeMapScreen />);
+  const output = shallow(<ParadeMapScreen isFocused={false} />);
   expect(output).toMatchSnapshot();
 });

--- a/src/screens/ParadeMapScreen/component.test.js
+++ b/src/screens/ParadeMapScreen/component.test.js
@@ -4,6 +4,11 @@ import { shallow } from "enzyme";
 import ParadeMapScreen from "./component";
 
 it("renders correctly", () => {
+  const output = shallow(<ParadeMapScreen isFocused />);
+  expect(output).toMatchSnapshot();
+});
+
+it("does not render map when not focused", () => {
   const output = shallow(<ParadeMapScreen />);
   expect(output).toMatchSnapshot();
 });

--- a/src/screens/ParadeMapScreen/index.js
+++ b/src/screens/ParadeMapScreen/index.js
@@ -1,4 +1,5 @@
 // @flow
+import withIsFocused from "../../components/WithIsFocused";
 import Component from "./component";
 
-export default Component;
+export default withIsFocused(Component);


### PR DESCRIPTION
I have no idea why, but changing from the prop `region` to `initialRegion` seems to stop the map from crashing on Android when zooming. We are able to maintain the same behavior of zooming back to the parade map when switching screens by wrapping with the `withIsFocused` HOC.

Please thoroughly test this on real devices before merging, especially on real Android devices. I have testing on emulators for iOS 6s and Android Nexus 5 and will test on my real iOS device too. 

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
