### PR TITLE
Bundle more recent version of Javascript Core(jsc) on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -222,6 +222,12 @@ repositories {
     maven { url 'https://maven.fabric.io/public' }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'org.webkit:android-jsc:r224109'
+    }
+}
+
 dependencies {
     implementation project(':react-native-haptic-feedback')
     implementation project(':lottie-react-native')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.versions = [
-        minSdk: 16,
+        minSdk: 21,
         compileSdk: 27,
         targetSdk: 27,
         buildTools: '27.0.3',
@@ -31,6 +31,10 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/../node_modules/jsc-android/dist"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bugsnag-react-native": "^2.9.3",
     "contentful": "^5.0.5",
     "core-js": "^2.5.6",
+    "jsc-android": "^224109.0.0",
     "lottie-react-native": "2.3.2",
     "luxon": "^1.2.0",
     "ramda": "^0.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4357,6 +4357,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@^224109.0.0:
+  version "224109.0.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.0.0.tgz#decd9f4b6f76280a01697a3be9c1e56620659c2a"
+
 jsdom@^11.5.1:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.8.0.tgz#a52e9a7d2b931284f62c80dad5f17d7390499d8b"


### PR DESCRIPTION
When using React Native, on iOS the platform jsc is used and on Android react native bundles it's own version.

This means that every new version of iOS will provide a "better" version of jsc to React Native apps while on Android the version being bundled is from 2014 and unlikely to change anytime soon. [link](https://github.com/facebook/react-native/issues/10245)

The community has responded by providing pre-built versions of jsc that are more up to date by distributing them through npm. That is what this PR uses.

One downside is that the minSdk has to be raised to 21 as this is a requirement of the npm package used.

Opening this for testing and feedback as to whether it provides any noticeable improvements.

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
