### PR TITLE
Reduce build log noise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,6 +459,10 @@ jobs:
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
+      - run:
+          name: Install xcpretty
+          command: |
+            gem install xcpretty
       # Not using a workspace here as Node and Yarn versions
       # differ between the macOS image and the Docker containers above.
       - <<: *fabric-secrets-ios

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -23,7 +23,9 @@ platform :ios do
       clean: true,
       export_method: options[:export_method],
       configuration: options[:configuration],
-      scheme: "PrideLondonApp"
+      scheme: "PrideLondonApp",
+      silent: true,
+      suppress_xcode_output: true,
     )
   end
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "detox test -c ios.sim.debug --loglevel verbose --debug-synchronization 1000",
     "test:e2e:build": "detox build -c ios.sim.debug",
     "test:e2e:release":
-      "detox build -c ios.sim.release && detox test -c ios.sim.release --loglevel verbose --debug-synchronization 1000",
+      "detox build -c ios.sim.release && detox test -c ios.sim.release",
     "precommit": "lint-staged",
     "lint": "eslint src",
     "flow": "flow src",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "binaryPath":
           "ios/build/Build/Products/Debug-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet",
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
@@ -133,7 +133,7 @@
         "binaryPath":
           "ios/build/Build/Products/Release-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
         "type": "ios.simulator",
         "name": "iPhone 7"
       }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "binaryPath":
           "ios/build/Build/Products/Debug-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
@@ -133,7 +133,7 @@
         "binaryPath":
           "ios/build/Build/Products/Release-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7"
       }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "binaryPath":
           "ios/build/Build/Products/Debug-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -quiet",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
@@ -133,7 +133,7 @@
         "binaryPath":
           "ios/build/Build/Products/Release-iphonesimulator/PrideLondonApp.app",
         "build":
-          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -quiet",
+          "xcodebuild -project ios/PrideLondonApp.xcodeproj -scheme PrideLondonApp -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcpretty",
         "type": "ios.simulator",
         "name": "iPhone 7"
       }


### PR DESCRIPTION
iOS builds notoriously have very long build logs, this makes it hard to find the actual error when there is one.

This PR:

- [x] uses quiet flag to only show warning/errors
- [x] on builds for distribution Xcode log is suppressed from stdout but remains available in buildlogs/
- [x] on e2e removes extra debugging flags from CI script