### PR TITLE
Don't set a valid bugsnag api key when running e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,9 +462,9 @@ jobs:
     <<: *job-defaults-macos
     working_directory: /Users/distiller/project
     environment:
-      - <<: *env-macos
-      - <<: *clear-bugsnag-api-key
+      <<: *env-macos
     steps:
+      - <<: *clear-bugsnag-api-key
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,7 @@ jobs:
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
+      - <<: *clear-bugsnag-api-key
       - run:
           name: Install xcpretty
           command: |
@@ -493,7 +494,6 @@ jobs:
       - <<: *get-yarn-cache-macos
       - <<: *yarn-dependencies-macos
       - <<: *save-yarn-cache-macos
-      - <<: *clear-bugsnag-api-key
       - <<: *generate-env-macos
       - run: npx detox clean-framework-cache && npx detox build-framework-cache
       - run: yarn test:e2e:release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,42 +526,42 @@ workflows:
     jobs:
       - build
       - e2e-ios
-      - alpha-android:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - master
-      - alpha-ios:
-          filters:
-            branches:
-              ignore:
-                - master
-      - beta-android:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-      - beta-ios:
-          filters:
-            branches:
-              only:
-                - master
-      - release-android:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-      - release-ios:
-          filters:
-            branches:
-              only:
-                - master
+      # - alpha-android:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      # - alpha-ios:
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - master
+      # - beta-android:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - beta-ios:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - release-android:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - release-ios:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
   nightly-release:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ clear-bugsnag-api-key: &clear-bugsnag-api-key
   run:
     name: clear value of BUGSNAG_API_KEY
     command: |
-      echo 'export BUGSNAG_API_KEY=1' >> $BASH_ENV
+      echo 'export BUGSNAG_API_KEY=$RELEASE_GOOGLE_MAPS_API_KEY' >> $BASH_ENV
       source $BASH_ENV
 
 bugsnag-upload-sourcemaps-android: &bugsnag-upload-sourcemaps-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,8 +462,8 @@ jobs:
     <<: *job-defaults-macos
     working_directory: /Users/distiller/project
     environment:
-      <<: *env-macos
-      <<: *clear-bugsnag-api-key
+      - <<: *env-macos
+      - <<: *clear-bugsnag-api-key
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ clear-bugsnag-api-key: &clear-bugsnag-api-key
   run:
     name: clear value of BUGSNAG_API_KEY
     command: |
-      echo 'export BUGSNAG_API_KEY=$RELEASE_GOOGLE_MAPS_API_KEY' >> $BASH_ENV
+      echo 'export BUGSNAG_API_KEY=1' >> $BASH_ENV
       source $BASH_ENV
 
 bugsnag-upload-sourcemaps-android: &bugsnag-upload-sourcemaps-android
@@ -466,11 +466,7 @@ jobs:
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
-      - run:
-          name: Clear value of BUGSNAG_API_KEY
-          command: |
-            echo 'export BUGSNAG_API_KEY=$RELEASE_GOOGLE_MAPS_API_KEY' >> $BASH_ENV
-            source $BASH_ENV
+      - <<: *clear-bugsnag-api-key
       - run:
           name: Install xcpretty
           command: |
@@ -530,42 +526,42 @@ workflows:
     jobs:
       - build
       - e2e-ios
-      # - alpha-android:
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      # - alpha-ios:
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      # - beta-android:
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - beta-ios:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - release-android:
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - release-ios:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
+      - alpha-android:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - master
+      - alpha-ios:
+          filters:
+            branches:
+              ignore:
+                - master
+      - beta-android:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - beta-ios:
+          filters:
+            branches:
+              only:
+                - master
+      - release-android:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - release-ios:
+          filters:
+            branches:
+              only:
+                - master
   nightly-release:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,7 +466,11 @@ jobs:
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
-      - <<: *clear-bugsnag-api-key
+      - run:
+          name: Clear value of BUGSNAG_API_KEY
+          command: |
+            echo 'export BUGSNAG_API_KEY=$RELEASE_GOOGLE_MAPS_API_KEY' >> $BASH_ENV
+            source $BASH_ENV
       - run:
           name: Install xcpretty
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,6 @@ jobs:
     environment:
       <<: *env-macos
     steps:
-      - <<: *clear-bugsnag-api-key
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos
       - run:
@@ -494,6 +493,7 @@ jobs:
       - <<: *get-yarn-cache-macos
       - <<: *yarn-dependencies-macos
       - <<: *save-yarn-cache-macos
+      - <<: *clear-bugsnag-api-key
       - <<: *generate-env-macos
       - run: npx detox clean-framework-cache && npx detox build-framework-cache
       - run: yarn test:e2e:release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,13 @@ release-api-keys: &release-api-keys
       echo 'export GOOGLE_MAPS_API_KEY=$RELEASE_GOOGLE_MAPS_API_KEY' >> $BASH_ENV
       source $BASH_ENV
 
+clear-bugsnag-api-key: &clear-bugsnag-api-key
+  run:
+    name: clear value of BUGSNAG_API_KEY
+    command: |
+      echo 'export BUGSNAG_API_KEY=1' >> $BASH_ENV
+      source $BASH_ENV
+
 bugsnag-upload-sourcemaps-android: &bugsnag-upload-sourcemaps-android
   run:
     name: Generate js sourcemaps and upload to Bugsnag
@@ -456,6 +463,7 @@ jobs:
     working_directory: /Users/distiller/project
     environment:
       <<: *env-macos
+      <<: *clear-bugsnag-api-key
     steps:
       - <<: *checkout-macos
       - <<: *set-ruby-version-macos


### PR DESCRIPTION
Still investigating as to why this only seems to have happened in master and not during the PR branch.

No need for e2e job to ever talk to Bugsnag so we set an invalid api key.