### PR TITLE
fix splash screen reanimating when refreshing data

### DIFF
--- a/src/reducers/splash-screen.js
+++ b/src/reducers/splash-screen.js
@@ -12,7 +12,7 @@ const splashScreen: Reducer<State, SupportedAction> = (
   state: State = defaultState,
   action: SupportedAction
 ) => {
-  if (action.type === "RECEIVE_CMS_DATA") {
+  if (action.type === "RECEIVE_CMS_DATA" && state === "showing") {
     return "hiding";
   }
 

--- a/src/reducers/splash-screen.test.js
+++ b/src/reducers/splash-screen.test.js
@@ -2,7 +2,7 @@
 import reducer from "./splash-screen";
 
 describe("Splash screen reducer", () => {
-  it("starts hiding splash screen on RECEIVE_CMS_DATA", () => {
+  it("starts hiding splash screen on RECEIVE_CMS_DATA and current state showing", () => {
     const data: any = null;
     const newState = reducer("showing", {
       type: "RECEIVE_CMS_DATA",
@@ -10,6 +10,16 @@ describe("Splash screen reducer", () => {
     });
 
     expect(newState).toBe("hiding");
+  });
+
+  it("remains hidden on RECEIVE_CMS_DATA when current state is hidden", () => {
+    const data: any = null;
+    const newState = reducer("hidden", {
+      type: "RECEIVE_CMS_DATA",
+      data
+    });
+
+    expect(newState).toBe("hidden");
   });
 
   it("hides splash screen on HIDE_SPLASH_SCREEN", () => {


### PR DESCRIPTION
This PR fixes #547. The splash screen should no longer reanimate when refreshing datas;