### PR TITLE
Move splashscreen hide to Splashscreen componentDidMount

### DIFF
--- a/src/screens/SplashScreen/component.js
+++ b/src/screens/SplashScreen/component.js
@@ -41,9 +41,11 @@ class SplashScreen extends Component<SplashScreenProps, State> {
     return null;
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
     SplashScreenController.hide();
+  }
 
+  componentDidUpdate() {
     if (this.props.state !== "hiding") return;
     if (!this.props.noDataReceived) {
       this.animateOut();

--- a/src/screens/SplashScreen/component.test.js
+++ b/src/screens/SplashScreen/component.test.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { View, Animated } from "react-native";
 import { shallow } from "enzyme";
+import SplashScreenController from "react-native-splash-screen";
 import SplashScreen from "./component";
 
 // all this mocking is making me sad.
@@ -10,6 +11,7 @@ const timingMock = jest.spyOn(Animated, "timing");
 const staggerMock = jest.spyOn(Animated, "stagger").mockImplementation(() => ({
   start: startMock
 }));
+const splashScreenControllerMock = jest.spyOn(SplashScreenController, "hide");
 
 it("renders correctly when showing", () => {
   const output = shallow(
@@ -41,6 +43,22 @@ it("renders correctly when hidden", () => {
   );
 
   expect(output).toMatchSnapshot();
+});
+
+it("calls splash screen controller hide on component mount", () => {
+  shallow(
+    <SplashScreen
+      state="showing"
+      onAnimationComplete={() => {}}
+      loading={false}
+      noDataReceived={false}
+      getData={() => {}}
+    >
+      hello
+    </SplashScreen>
+  );
+
+  expect(splashScreenControllerMock).toHaveBeenCalled();
 });
 
 describe("Animation", () => {


### PR DESCRIPTION
Fixes #556 

Crash occurred because iOS imposes ~20 second limit on how long the SplashScreen can be shown for.

## Tester check-list

  * [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings