### PR TITLE
Stage marker layering behaviour

### DIFF
--- a/src/screens/ParadeMapScreen/Map.js
+++ b/src/screens/ParadeMapScreen/Map.js
@@ -151,7 +151,7 @@ class Map extends PureComponent<Props, State> {
     this.setState({ tileDetails: stage, activeMarker: stage.id });
   };
 
-  handleMapPress = () => {
+  dismissEventTile = () => {
     this.setState({ tileDetails: null, activeMarker: null });
   };
 
@@ -201,7 +201,7 @@ class Map extends PureComponent<Props, State> {
           showsBuildings={false}
           showsTraffic={false}
           showsIndoors={false}
-          onPress={this.handleMapPress}
+          onPress={this.dismissEventTile}
         >
           <Polyline
             coordinates={this.props.route}
@@ -212,10 +212,12 @@ class Map extends PureComponent<Props, State> {
           <TerminalMarkers
             terminals={terminals}
             markerSelect={this.handleIOSMarkerSelect}
+            handleMarkerPress={this.dismissEventTile}
           />
           <AmenityMarkers
             amenities={amenities}
             markerSelect={this.handleIOSMarkerSelect}
+            handleMarkerPress={this.dismissEventTile}
           />
           <StageMarkers
             stages={stages}

--- a/src/screens/ParadeMapScreen/Map.test.js
+++ b/src/screens/ParadeMapScreen/Map.test.js
@@ -179,6 +179,16 @@ describe("handleMarkerPress", () => {
   });
 });
 
+describe("dismissEventTile", () => {
+  it("updates state clearing stage marker details", () => {
+    const output = render(regionProps);
+    const dismissEventTileSpy = output.instance().dismissEventTile;
+    dismissEventTileSpy();
+    expect(output.state().tileDetails).toEqual(null);
+    expect(output.state().activeMarker).toEqual(null);
+  });
+});
+
 describe("handleIOSMarkerSelect", () => {
   it("animates to marker coordinates", () => {
     const output = render(regionProps);

--- a/src/screens/ParadeMapScreen/StageMarkers.js
+++ b/src/screens/ParadeMapScreen/StageMarkers.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Fragment } from "react";
+import { StyleSheet } from "react-native";
 import { Marker } from "react-native-maps";
 import { uniqWith, eqBy } from "ramda";
 import type { Event } from "../../data/event";
@@ -30,7 +31,6 @@ const StageMarkers = ({
     <Fragment>
       {uniqueStages.map(stage => (
         <Marker
-          zIndex={1}
           coordinate={{
             longitude: stage.fields.location.lon,
             latitude: stage.fields.location.lat
@@ -42,10 +42,26 @@ const StageMarkers = ({
             activeMarker === stage.id ? stageIconActive : stageIconInactive
           }
           onSelect={markerSelect}
+          style={
+            activeMarker === stage.id
+              ? styles.stageMarkerActiveStyle
+              : styles.stageMarkerInactiveStyle
+          }
         />
       ))}
     </Fragment>
   );
 };
+
+const styles = StyleSheet.create({
+  stageMarkerInactiveStyle: {
+    zIndex: 1
+  },
+  stageMarkerActiveStyle: {
+    // React Native Maps adds a constant to the currently open callout, but if the stage marker is active we want to move it above this
+    // https://github.com/react-community/react-native-maps/blob/080678b24f886c3b8104206f2f80452ee723243a/lib/ios/AirMaps/AIRMapMarker.m#L316
+    zIndex: 1001
+  }
+});
 
 export default StageMarkers;

--- a/src/screens/ParadeMapScreen/StageMarkers.test.js
+++ b/src/screens/ParadeMapScreen/StageMarkers.test.js
@@ -21,6 +21,19 @@ describe("AmenityMarkers component", () => {
     expect(output).toMatchSnapshot();
   });
 
+  it("renders correctly when it's the currently selected stage", () => {
+    const output = shallow(
+      <StageMarkers
+        stages={[stage]}
+        // eslint-disable-next-line no-unused-vars
+        handleMarkerPress={(_: Event) => {}}
+        activeMarker={stage.id}
+        markerSelect={() => {}}
+      />
+    );
+    expect(output).toMatchSnapshot();
+  });
+
   it("renders nothing when no amenities provided", () => {
     const output = shallow(
       <StageMarkers

--- a/src/screens/ParadeMapScreen/__snapshots__/Map.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/Map.test.js.snap
@@ -541,6 +541,7 @@ exports[`Map component renders correctly 1`] = `
       strokeWidth={5}
     />
     <TerminalMarkers
+      handleMarkerPress={[Function]}
       markerSelect={[Function]}
       terminals={
         Array [
@@ -581,6 +582,7 @@ exports[`Map component renders correctly 1`] = `
           },
         ]
       }
+      handleMarkerPress={[Function]}
       markerSelect={[Function]}
     />
     <StageMarkers
@@ -1253,6 +1255,7 @@ exports[`Map component renders without location button when permission is restri
       strokeWidth={5}
     />
     <TerminalMarkers
+      handleMarkerPress={[Function]}
       markerSelect={[Function]}
       terminals={
         Array [
@@ -1293,6 +1296,7 @@ exports[`Map component renders without location button when permission is restri
           },
         ]
       }
+      handleMarkerPress={[Function]}
       markerSelect={[Function]}
     />
     <StageMarkers

--- a/src/screens/ParadeMapScreen/__snapshots__/StageMarkers.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/StageMarkers.test.js.snap
@@ -22,3 +22,26 @@ exports[`AmenityMarkers component renders correctly 1`] = `
   />
 </React.Fragment>
 `;
+
+exports[`AmenityMarkers component renders correctly when it's the currently selected stage 1`] = `
+<React.Fragment>
+  <MapMarker
+    coordinate={
+      Object {
+        "latitude": 0,
+        "longitude": 10,
+      }
+    }
+    image={1}
+    key="QF4dTqmpn9z5ItEizAZ"
+    onPress={[Function]}
+    onSelect={[Function]}
+    stopPropagation={true}
+    style={
+      Object {
+        "zIndex": 1001,
+      }
+    }
+  />
+</React.Fragment>
+`;

--- a/src/screens/ParadeMapScreen/__snapshots__/StageMarkers.test.js.snap
+++ b/src/screens/ParadeMapScreen/__snapshots__/StageMarkers.test.js.snap
@@ -14,7 +14,11 @@ exports[`AmenityMarkers component renders correctly 1`] = `
     onPress={[Function]}
     onSelect={[Function]}
     stopPropagation={true}
-    zIndex={1}
+    style={
+      Object {
+        "zIndex": 1,
+      }
+    }
   />
 </React.Fragment>
 `;


### PR DESCRIPTION
This PR is to fix #567 and improve behaviour of the layering of the markers. If an amenity is selected the currently selected stage should be unselected and that amenity marker should be drawn above. Otherwise stages appear above amenities and a selected stage should appear above everything else. 

I followed this [Z Index Marker](https://github.com/react-community/react-native-maps/blob/master/example/examples/ZIndexMarkers.js) example to apply the z indexes. 

It was also useful to see the way react native maps manipulates the z indexes based on open callouts.

https://github.com/react-community/react-native-maps/blob/080678b24f886c3b8104206f2f80452ee723243a/lib/ios/AirMaps/AIRMapMarker.m#L316

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6