### PR TITLE
decrease font size of CategoryPill

### DIFF
--- a/src/components/CategoryPill.js
+++ b/src/components/CategoryPill.js
@@ -3,7 +3,7 @@ import React from "react";
 import { View, StyleSheet } from "react-native";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
 import { hyphenate } from "../lib/string";
-import Text from "./Text";
+import Text, { scaleFont } from "./Text";
 import Touchable from "./Touchable";
 import type { EventCategoryName } from "../data/event";
 import { getEventCategoryFromName } from "../data/event";
@@ -62,7 +62,8 @@ const styles = StyleSheet.create({
   },
   categoryPillText: {
     color: whiteColor,
-    paddingTop: 3
+    paddingTop: 3,
+    fontSize: scaleFont("h3", 15) // tweak h3 to be slightly smaller (GH-155)
   }
 });
 

--- a/src/components/__snapshots__/CategoryPill.test.js.snap
+++ b/src/components/__snapshots__/CategoryPill.test.js.snap
@@ -24,6 +24,7 @@ exports[`CategoryPill Component renders correctly 1`] = `
       Array [
         Object {
           "color": "#ffffff",
+          "fontSize": 15,
           "paddingTop": 3,
         },
         Object {


### PR DESCRIPTION
Fixes #155. Make category pill text size slightly smaller so we can have more on a single line on the event details screen.

**Note:** This will also affect the filter screen pill size when categories are selected and the home screen category labels over each event. It would be good to get UXD input here if that is ok.

I have looked into the contrast ratios of the pills and I think we may have misunderstood reaching AA standard. The table below outlines the standard that the combination of background and foreground color currently produces. Of note are the ones that only reach `AA Large` standard. This means that we should only be using this combo when the font size is 24 px or larger. The Current size of font for Category pills is 16 and with this change, reduces it to 15. Interestingly if we change the foreground color to black we reach the AA standard which allows any font size.

| Label | Background | Foreground | Accessibility Standard | If Foreground Black |
| ----- | ---------- | ---------- | ---------------------- | ------------------- |
| Cabaret and Variety | Coral | White | AA Large | AA |
| Community | Bright Light Blue | Black | AAA | - |
| Talks and Debates | Dark Sky Blue | White | AA Large | AA |
| Film and Screenings | Light Teal | Black | AAA | - |
| Plays and Theatre | Warm Pink | White | AA Large | AA |
| Social and Networking | Turquoise Blue | Black | AA | - |
| Nightlife | Yellow Color | Black | AAA | - |
| Exhibition and Tours | Bright Purple | White | AA | AA |
| Sports and Activities | Vomit Yellow | Black | AAA | - |
| Health | Bubblegum Pink | Black | AAA | - |
| Music | Cornflower Blue | White | AA | AA |