### PR TITLE
Message bar component rxjs fix

### DIFF
--- a/src/lib/geolocation.test.js
+++ b/src/lib/geolocation.test.js
@@ -2,7 +2,7 @@
 import { Alert, Linking, Platform } from "react-native";
 import Permissions from "react-native-permissions";
 import { TestScheduler } from "rxjs/testing";
-import { merge, VirtualTimeScheduler, empty } from "rxjs";
+import { merge, empty } from "rxjs";
 import { last, skip, take, tap, flatMap } from "rxjs/operators";
 import {
   passiveLocationStream,

--- a/src/lib/geolocation.test.js
+++ b/src/lib/geolocation.test.js
@@ -232,6 +232,7 @@ describe("locationStatusStream", () => {
     watchPosition.mockImplementationOnce(cb => {
       callback = cb;
     });
+    // See https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md
     const scheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
     });
@@ -253,6 +254,7 @@ describe("locationStatusStream", () => {
     watchPosition.mockImplementationOnce(cb => {
       callback = cb;
     });
+    // See https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md
     const scheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
Update the implementation of `locationStatusStream` to timeout after 3000ms of no messages. This also adds tests around this using `rxjs` TestScheduler and its marble diagrams 😱. See this for more info: https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md