### PR TITLE
status bar now has correct height to include back link on iphone X

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,6 @@
     "react-test-renderer": "16.2.0",
     "redux-mock-store": "^1.5.3"
   },
-  "resolutions": {
-    "react-native-safe-area-view": "robbiemccorkell/react-native-safe-area-view"
-  },
   "rnpm": {
     "assets": [
       "./assets/fonts/"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-native-map-link": "^1.0.6",
     "react-native-maps": "^0.21.0",
     "react-native-permissions": "^1.1.1",
-    "react-native-safe-area-view": "robbiemccorkell/react-native-safe-area-view",
+    "react-native-safe-area-view": "^0.9.0",
     "react-native-splash-screen": "^3.0.6",
     "react-navigation": "^2.0.1",
     "react-redux": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6203,6 +6203,12 @@ react-native-safe-area-view@^0.7.0, react-native-safe-area-view@robbiemccorkell/
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
+react-native-safe-area-view@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.9.0.tgz#10ece2ecac70e7005a5b0b3f06c8833060e6d21f"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-safe-module@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-module/-/react-native-safe-module-1.2.0.tgz#a23824ca24edc2901913694a76646475113d570d"


### PR DESCRIPTION
#445 

Fixed issue with the overflowing back link in the status bar by updating the version of 'react-native-safe-area-view'.

![simulator screen shot - iphone x - 2018-07-06 at 14 36 11](https://user-images.githubusercontent.com/11501555/42383009-e4c2d116-812d-11e8-9701-8bd521f3a8b9.png)

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
