### PR TITLE
Optimize Contentful image loading

### DIFF
--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -21,9 +21,11 @@ export const ImageBackground = ({
   reference,
   getImageDetails,
   ...props
-}: Props) => (
-  <RNImageBackground source={getImageDetails(reference.sys.id)} {...props} />
-);
+}: Props) => {
+  const imgSrc = getImageDetails(reference.sys.id, { width: 50, height: 25 });
+  console.log("ImageBackground source", imgSrc);
+  return <RNImageBackground source={imgSrc} {...props} />;
+};
 
 // Note we must add a return type here for react-redux connect to work
 // with flow correctly. If not provided is silently fails if types do

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -23,13 +23,13 @@ export class ImageBackground extends Component<Props, State> {
     this.state = { imageSize: null };
   }
 
-  onLayout({
+  onLayout = ({
     nativeEvent: {
       layout: { width, height }
     }
-  }) {
+  }) => {
     this.setState({ imageSize: { width, height } });
-  }
+  };
 
   render() {
     const { reference, getImageDetails, ...props } = this.props;
@@ -48,11 +48,7 @@ export class ImageBackground extends Component<Props, State> {
       : imageNotLoadedPlaceholder;
 
     return (
-      <RNImageBackground
-        onLayout={this.onLayout.bind(this)}
-        source={imgSrc}
-        {...props}
-      />
+      <RNImageBackground onLayout={this.onLayout} source={imgSrc} {...props} />
     );
   }
 }

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -3,10 +3,10 @@ import React, { Component } from "react";
 import { ImageBackground as RNImageBackground } from "react-native";
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
+import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
 import type { ImageDetails } from "../data/image";
 import { getImageDetails as createImageDetailsGetter } from "../data/image";
 import type { FieldRef } from "../data/field-ref";
-import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
 
 type OwnProps = {
   reference: FieldRef

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -11,8 +11,12 @@ type OwnProps = {
   reference: FieldRef
 };
 
+type State = {
+  imageSize: ?{ width: number, height: number }
+};
+
 type StateProps = {
-  getImageDetails: string => ?ImageDetails
+  getImageDetails: (string, { width: number, height: number }) => ?ImageDetails
 };
 
 type Props = OwnProps & StateProps;
@@ -23,12 +27,13 @@ export class ImageBackground extends Component<Props, State> {
     this.state = { imageSize: null };
   }
 
-  onLayout = ({
-    nativeEvent: {
-      layout: { width, height }
-    }
-  }) => {
-    this.setState({ imageSize: { width, height } });
+  onLayout = (event: Object) => {
+    this.setState({
+      imageSize: {
+        width: event.nativeEvent.layout.width,
+        height: event.nativeEvent.layout.height
+      }
+    });
   };
 
   render() {

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import React, { Component } from "react";
 import { ImageBackground as RNImageBackground } from "react-native";
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
@@ -17,15 +17,49 @@ type StateProps = {
 
 type Props = OwnProps & StateProps;
 
-export const ImageBackground = ({
+/*export const ImageBackground = ({
   reference,
   getImageDetails,
   ...props
 }: Props) => {
-  const imgSrc = getImageDetails(reference.sys.id, { width: 50, height: 25 });
-  console.log("ImageBackground source", imgSrc);
-  return <RNImageBackground source={imgSrc} {...props} />;
-};
+
+};*/
+
+class ImageBackground extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { imageSize: null };
+  }
+
+  render() {
+    const { reference, getImageDetails, ...props } = this.props;
+
+    const imageNotLoadedPlaceholder = {
+      uri:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5/hPwAIAgL/4d1j8wAAAABJRU5ErkJggg=="
+    };
+    const imgSrc = this.state.imageSize
+      ? getImageDetails(reference.sys.id, {
+          width: this.state.imageSize.width,
+          height: this.state.imageSize.height
+        })
+      : imageNotLoadedPlaceholder;
+    return (
+      <RNImageBackground
+        onLayout={({
+          nativeEvent: {
+            layout: { width, height }
+          }
+        }) => {
+          console.log(this.state.imageSize);
+          this.setState({ imageSize: { width, height } });
+        }}
+        source={imgSrc}
+        {...props}
+      />
+    );
+  }
+}
 
 // Note we must add a return type here for react-redux connect to work
 // with flow correctly. If not provided is silently fails if types do

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -17,43 +17,39 @@ type StateProps = {
 
 type Props = OwnProps & StateProps;
 
-/*export const ImageBackground = ({
-  reference,
-  getImageDetails,
-  ...props
-}: Props) => {
-
-};*/
-
 class ImageBackground extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { imageSize: null };
   }
 
+  onLayout({
+    nativeEvent: {
+      layout: { width, height }
+    }
+  }) {
+    this.setState({ imageSize: { width, height } });
+  }
+
   render() {
     const { reference, getImageDetails, ...props } = this.props;
 
+    // Single transparent pixel rendered initally so image size can be measured
     const imageNotLoadedPlaceholder = {
       uri:
         "data:image/png;base64,  iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
     };
+
     const imgSrc = this.state.imageSize
       ? getImageDetails(reference.sys.id, {
           width: this.state.imageSize.width,
           height: this.state.imageSize.height
         })
       : imageNotLoadedPlaceholder;
+
     return (
       <RNImageBackground
-        onLayout={({
-          nativeEvent: {
-            layout: { width, height }
-          }
-        }) => {
-          console.log(this.state.imageSize);
-          this.setState({ imageSize: { width, height } });
-        }}
+        onLayout={this.onLayout.bind(this)}
         source={imgSrc}
         {...props}
       />

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -36,7 +36,7 @@ class ImageBackground extends Component<Props, State> {
 
     const imageNotLoadedPlaceholder = {
       uri:
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5/hPwAIAgL/4d1j8wAAAABJRU5ErkJggg=="
+        "data:image/png;base64,  iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
     };
     const imgSrc = this.state.imageSize
       ? getImageDetails(reference.sys.id, {

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -17,7 +17,7 @@ type StateProps = {
 
 type Props = OwnProps & StateProps;
 
-class ImageBackground extends Component<Props, State> {
+export class ImageBackground extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { imageSize: null };

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -6,6 +6,7 @@ import type { Connector } from "react-redux";
 import type { ImageDetails } from "../data/image";
 import { getImageDetails as createImageDetailsGetter } from "../data/image";
 import type { FieldRef } from "../data/field-ref";
+import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
 
 type OwnProps = {
   reference: FieldRef
@@ -27,7 +28,7 @@ export class ImageBackground extends Component<Props, State> {
     this.state = { imageSize: null };
   }
 
-  onLayout = (event: Object) => {
+  onLayout = (event: LayoutEvent) => {
     this.setState({
       imageSize: {
         width: event.nativeEvent.layout.width,

--- a/src/components/ImageBackground.test.js
+++ b/src/components/ImageBackground.test.js
@@ -4,7 +4,7 @@ import { shallow } from "enzyme";
 import { sampleOne, generateImageDetails } from "../data/__test-data";
 import { ImageBackground } from "./ImageBackground";
 
-it("renders correctly", () => {
+it("renders placeholder image correctly", () => {
   const getImageDetails = () => sampleOne(generateImageDetails);
   const reference = { sys: { id: "a" } };
   const output = shallow(
@@ -15,5 +15,26 @@ it("renders correctly", () => {
       accessibilityLabel="Test Label"
     />
   );
+  expect(output).toMatchSnapshot();
+});
+
+it("renders image correctly", () => {
+  const getImageDetails = jest.fn(() => sampleOne(generateImageDetails));
+  const reference = { sys: { id: "a" } };
+  const layoutDimensions = { width: 500, height: 200 };
+  const output = shallow(
+    <ImageBackground
+      getImageDetails={getImageDetails}
+      reference={reference}
+      resizeMode="contain"
+      accessibilityLabel="Test Label"
+    />
+  );
+
+  output.instance().onLayout({ nativeEvent: { layout: layoutDimensions } });
+  output.update();
+
+  expect(getImageDetails).toHaveBeenCalledTimes(1);
+  expect(getImageDetails).toBeCalledWith(reference.sys.id, layoutDimensions);
   expect(output).toMatchSnapshot();
 });

--- a/src/components/__snapshots__/ImageBackground.test.js.snap
+++ b/src/components/__snapshots__/ImageBackground.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`renders image correctly 1`] = `
 <ImageBackground
   accessibilityLabel="Test Label"
+  onLayout={[Function]}
   resizeMode="contain"
   source={
     Object {
@@ -11,6 +12,19 @@ exports[`renders correctly 1`] = `
       "revision": 1,
       "uri": "https://red-badger.com/56K46slQYXyq6SOU4UzWUW8eL7iJg.jpg",
       "width": 891,
+    }
+  }
+/>
+`;
+
+exports[`renders placeholder image correctly 1`] = `
+<ImageBackground
+  accessibilityLabel="Test Label"
+  onLayout={[Function]}
+  resizeMode="contain"
+  source={
+    Object {
+      "uri": "data:image/png;base64,  iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
     }
   }
 />

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -18,11 +18,13 @@ export const getImageDetails = (images: Images) => (
   id: string,
   dimensions: ?{ width: number, height: number }
 ): ?ImageDetails => {
-  if (!dimensions) {
-    return images[id];
+  const imageDetails = images[id];
+
+  // Image details might be undefined in case of unpublished image
+  if (!dimensions || !imageDetails) {
+    return imageDetails;
   }
 
-  const imageDetails = images[id];
   const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
     dimensions.width
   }&h=${dimensions.height}&fit=fill`;

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -24,7 +24,7 @@ export const getImageDetails = (images: Images) => (
     const imageDetails = images[id];
     const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
       dimensions.width
-    }&h=${dimensions.height}&fit=pad`;
+    }&h=${dimensions.height}&fit=fill`;
     return Object.assign({}, imageDetails, {
       uri: imageUriWithResizingBehaviourParameters
     });

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -16,7 +16,7 @@ export type ImageDetails = {
 
 export const getImageDetails = (images: Images) => (
   id: string,
-  dimensions: { width: number, height: number }
+  dimensions: ?{ width: number, height: number }
 ): ?ImageDetails => {
   if (!dimensions) {
     return images[id];

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -20,15 +20,15 @@ export const getImageDetails = (images: Images) => (
 ): ?ImageDetails => {
   if (!dimensions) {
     return images[id];
-  } else {
-    const imageDetails = images[id];
-    const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
-      dimensions.width
-    }&h=${dimensions.height}&fit=fill`;
-    return Object.assign({}, imageDetails, {
-      uri: imageUriWithResizingBehaviourParameters
-    });
   }
+
+  const imageDetails = images[id];
+  const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
+    dimensions.width
+  }&h=${dimensions.height}&fit=fill`;
+  return Object.assign({}, imageDetails, {
+    uri: imageUriWithResizingBehaviourParameters
+  });
 };
 
 export const decodeImageDetails = (locale: string): Decoder<ImageDetails> =>

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -15,8 +15,21 @@ export type ImageDetails = {
 };
 
 export const getImageDetails = (images: Images) => (
-  id: string
-): ?ImageDetails => images[id];
+  id: string,
+  dimensions: { width: number, height: number }
+): ?ImageDetails => {
+  if (!dimensions) {
+    return images[id];
+  } else {
+    const imageDetails = images[id];
+    const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
+      dimensions.width
+    }&h=${dimensions.height}&fit=pad`;
+    return Object.assign({}, imageDetails, {
+      uri: imageUriWithResizingBehaviourParameters
+    });
+  }
+};
 
 export const decodeImageDetails = (locale: string): Decoder<ImageDetails> =>
   decode.shape({

--- a/src/data/image.test.js
+++ b/src/data/image.test.js
@@ -38,6 +38,15 @@ describe("image", () => {
     });
   });
 
+  it("returns correctly when dimensions are provided but there is no image details for image id", () => {
+    const imageDimensions = { width: 500, height: 200 };
+    const imageId = "image-id";
+
+    const getter = getImageDetails({});
+
+    expect(getter(imageId, imageDimensions)).toBeUndefined();
+  });
+
   describe("decodeImageDetails", () => {
     it("correctly decodes valid CMS image", () => {
       const data: mixed = sampleOne(generateCMSImage);

--- a/src/data/image.test.js
+++ b/src/data/image.test.js
@@ -17,6 +17,25 @@ describe("image", () => {
 
       expect(getter(imageDetails.id)).toEqual(imageDetails);
     });
+
+    it("returns the correct imageDetails when dimensions are provided", () => {
+      const imageDetails: ImageDetails = sampleOne(generateImageDetails);
+      const imageDimensions = { width: 500, height: 200 };
+      const imageDetailsWithDimensions = {
+        ...imageDetails,
+        uri: `${imageDetails.uri}?w=${imageDimensions.width}&h=${
+          imageDimensions.height
+        }&fit=fill`
+      };
+
+      const getter = getImageDetails({
+        [imageDetails.id]: imageDetails
+      });
+
+      expect(getter(imageDetails.id, imageDimensions)).toEqual(
+        imageDetailsWithDimensions
+      );
+    });
   });
 
   describe("decodeImageDetails", () => {


### PR DESCRIPTION
Implemention for #587 

Render transparent image initally and then request an image of the rendered size.

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6
