### PR TITLE
add same background to App as Spash on android;

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:windowBackground">@drawable/background_splash</item>
     </style>
 
 


### PR DESCRIPTION
Fixes #591. This should fix the white screen flash Android users see when updating the app. This does not seem to happen when opening an already installed app (that has been opened before) **Note:** There is still a fade of solid color. I'm not sure how to get rid of this.

In order to test you will need to uninstall the app an reinstall it.

## Tester check-list

* [ ] Tested on a number of Android devices:

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6