### PR TITLE
Disables e2e until can be fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,7 @@ workflows:
   node-android-ios:
     jobs:
       - build
-      - e2e-ios
+      # - e2e-ios
       - alpha-android:
           requires:
             - build


### PR DESCRIPTION
This is going to get annoying very fast so lets just disable e2e until we can have time to fix the issue

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
