### PR TITLE
Revert "Optimize Contentful image loading"

### DIFF
--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -1,9 +1,8 @@
 // @flow
-import React, { Component } from "react";
+import React from "react";
 import { ImageBackground as RNImageBackground } from "react-native";
 import { connect } from "react-redux";
 import type { Connector } from "react-redux";
-import type { LayoutEvent } from "react-native/Libraries/Types/CoreEventTypes";
 import type { ImageDetails } from "../data/image";
 import { getImageDetails as createImageDetailsGetter } from "../data/image";
 import type { FieldRef } from "../data/field-ref";
@@ -12,52 +11,19 @@ type OwnProps = {
   reference: FieldRef
 };
 
-type State = {
-  imageSize: ?{ width: number, height: number }
-};
-
 type StateProps = {
-  getImageDetails: (string, { width: number, height: number }) => ?ImageDetails
+  getImageDetails: string => ?ImageDetails
 };
 
 type Props = OwnProps & StateProps;
 
-export class ImageBackground extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { imageSize: null };
-  }
-
-  onLayout = (event: LayoutEvent) => {
-    this.setState({
-      imageSize: {
-        width: event.nativeEvent.layout.width,
-        height: event.nativeEvent.layout.height
-      }
-    });
-  };
-
-  render() {
-    const { reference, getImageDetails, ...props } = this.props;
-
-    // Single transparent pixel rendered initally so image size can be measured
-    const imageNotLoadedPlaceholder = {
-      uri:
-        "data:image/png;base64,  iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-    };
-
-    const imgSrc = this.state.imageSize
-      ? getImageDetails(reference.sys.id, {
-          width: this.state.imageSize.width,
-          height: this.state.imageSize.height
-        })
-      : imageNotLoadedPlaceholder;
-
-    return (
-      <RNImageBackground onLayout={this.onLayout} source={imgSrc} {...props} />
-    );
-  }
-}
+export const ImageBackground = ({
+  reference,
+  getImageDetails,
+  ...props
+}: Props) => (
+  <RNImageBackground source={getImageDetails(reference.sys.id)} {...props} />
+);
 
 // Note we must add a return type here for react-redux connect to work
 // with flow correctly. If not provided is silently fails if types do

--- a/src/components/ImageBackground.test.js
+++ b/src/components/ImageBackground.test.js
@@ -4,7 +4,7 @@ import { shallow } from "enzyme";
 import { sampleOne, generateImageDetails } from "../data/__test-data";
 import { ImageBackground } from "./ImageBackground";
 
-it("renders placeholder image correctly", () => {
+it("renders correctly", () => {
   const getImageDetails = () => sampleOne(generateImageDetails);
   const reference = { sys: { id: "a" } };
   const output = shallow(
@@ -15,26 +15,5 @@ it("renders placeholder image correctly", () => {
       accessibilityLabel="Test Label"
     />
   );
-  expect(output).toMatchSnapshot();
-});
-
-it("renders image correctly", () => {
-  const getImageDetails = jest.fn(() => sampleOne(generateImageDetails));
-  const reference = { sys: { id: "a" } };
-  const layoutDimensions = { width: 500, height: 200 };
-  const output = shallow(
-    <ImageBackground
-      getImageDetails={getImageDetails}
-      reference={reference}
-      resizeMode="contain"
-      accessibilityLabel="Test Label"
-    />
-  );
-
-  output.instance().onLayout({ nativeEvent: { layout: layoutDimensions } });
-  output.update();
-
-  expect(getImageDetails).toHaveBeenCalledTimes(1);
-  expect(getImageDetails).toBeCalledWith(reference.sys.id, layoutDimensions);
   expect(output).toMatchSnapshot();
 });

--- a/src/components/__snapshots__/ImageBackground.test.js.snap
+++ b/src/components/__snapshots__/ImageBackground.test.js.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders image correctly 1`] = `
+exports[`renders correctly 1`] = `
 <ImageBackground
   accessibilityLabel="Test Label"
-  onLayout={[Function]}
   resizeMode="contain"
   source={
     Object {
@@ -12,19 +11,6 @@ exports[`renders image correctly 1`] = `
       "revision": 1,
       "uri": "https://red-badger.com/56K46slQYXyq6SOU4UzWUW8eL7iJg.jpg",
       "width": 891,
-    }
-  }
-/>
-`;
-
-exports[`renders placeholder image correctly 1`] = `
-<ImageBackground
-  accessibilityLabel="Test Label"
-  onLayout={[Function]}
-  resizeMode="contain"
-  source={
-    Object {
-      "uri": "data:image/png;base64,  iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
     }
   }
 />

--- a/src/data/image.js
+++ b/src/data/image.js
@@ -15,23 +15,8 @@ export type ImageDetails = {
 };
 
 export const getImageDetails = (images: Images) => (
-  id: string,
-  dimensions: ?{ width: number, height: number }
-): ?ImageDetails => {
-  const imageDetails = images[id];
-
-  // Image details might be undefined in case of unpublished image
-  if (!dimensions || !imageDetails) {
-    return imageDetails;
-  }
-
-  const imageUriWithResizingBehaviourParameters = `${imageDetails.uri}?w=${
-    dimensions.width
-  }&h=${dimensions.height}&fit=fill`;
-  return Object.assign({}, imageDetails, {
-    uri: imageUriWithResizingBehaviourParameters
-  });
-};
+  id: string
+): ?ImageDetails => images[id];
 
 export const decodeImageDetails = (locale: string): Decoder<ImageDetails> =>
   decode.shape({

--- a/src/data/image.test.js
+++ b/src/data/image.test.js
@@ -17,34 +17,6 @@ describe("image", () => {
 
       expect(getter(imageDetails.id)).toEqual(imageDetails);
     });
-
-    it("returns the correct imageDetails when dimensions are provided", () => {
-      const imageDetails: ImageDetails = sampleOne(generateImageDetails);
-      const imageDimensions = { width: 500, height: 200 };
-      const imageDetailsWithDimensions = {
-        ...imageDetails,
-        uri: `${imageDetails.uri}?w=${imageDimensions.width}&h=${
-          imageDimensions.height
-        }&fit=fill`
-      };
-
-      const getter = getImageDetails({
-        [imageDetails.id]: imageDetails
-      });
-
-      expect(getter(imageDetails.id, imageDimensions)).toEqual(
-        imageDetailsWithDimensions
-      );
-    });
-  });
-
-  it("returns correctly when dimensions are provided but there is no image details for image id", () => {
-    const imageDimensions = { width: 500, height: 200 };
-    const imageId = "image-id";
-
-    const getter = getImageDetails({});
-
-    expect(getter(imageId, imageDimensions)).toBeUndefined();
   });
 
   describe("decodeImageDetails", () => {


### PR DESCRIPTION
Reverts redbadger/pride-london-app#593

We are seeing issues with this PR in master where some images never update to show the server image:
<img width="559" alt="screenshot 2018-11-19 at 6 29 42 pm" src="https://user-images.githubusercontent.com/2011550/48727111-344bd780-ec29-11e8-9c8e-0abaa998a62f.png">

Will reopen the original PR and investigate.