### PR TITLE
Update e2e case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,7 @@ workflows:
   node-android-ios:
     jobs:
       - build
-      # - e2e-ios
+      - e2e-ios
       - alpha-android:
           requires:
             - build

--- a/e2e/events.spec.js
+++ b/e2e/events.spec.js
@@ -2,10 +2,11 @@ const { formatDateRange } = require("../src/data/formatters");
 
 const formattedDateNumber = num => (num < 10 ? `0${num}` : num);
 
-const today = new Date();
-const thisDay = today.getDate();
-const thisMonth = today.getMonth() + 1;
-const thisYear = today.getFullYear();
+// We hardcode a date that ensures events
+const festivalStartDay = new Date("2019-07-01");
+const thisDay = festivalStartDay.getDate();
+const thisMonth = festivalStartDay.getMonth() + 1;
+const thisYear = festivalStartDay.getFullYear();
 const lastDayOfMonth = new Date(thisYear, thisMonth, 0).getDate();
 
 const formattedDay = formattedDateNumber(thisDay);

--- a/e2e/events.spec.js
+++ b/e2e/events.spec.js
@@ -2,11 +2,10 @@ const { formatDateRange } = require("../src/data/formatters");
 
 const formattedDateNumber = num => (num < 10 ? `0${num}` : num);
 
-// We hardcode a date that ensures events
-const festivalStartDay = new Date("2019-07-01");
-const thisDay = festivalStartDay.getDate();
-const thisMonth = festivalStartDay.getMonth() + 1;
-const thisYear = festivalStartDay.getFullYear();
+const today = new Date();
+const thisDay = today.getDate();
+const thisMonth = today.getMonth() + 1;
+const thisYear = today.getFullYear();
 const lastDayOfMonth = new Date(thisYear, thisMonth, 0).getDate();
 
 const formattedDay = formattedDateNumber(thisDay);


### PR DESCRIPTION
Date filtering e2e case would fail as no events in the used date range. 
This PR naively changes to always use July when we have events.

## Pre-flight check-list

Before raising a pull request

* [ ] Documentation
* [ ] Unit tests

## Pre-merge check-list

* [ ] Link to Trello ticket/GitHub issue (If applicable)
* [ ] Any risky areas identified
* [ ] Test plan provided
* [ ] Tester approved

## Tester check-list

* [ ] Tested on multiple devices / OS versions (Test on the physical device(s) you have access to, otherwise use BrowserStack):

  * [ ] Galaxy S8 (Android 7.0/8.0)
  * [ ] Galaxy S7 (Android 6.0)
  * [ ] iPhone X (iOS 11.x)
  * [ ] iPhone 8 (11.x)
  * [ ] iPhone 7 (iOS 10.x)

  Optional:

  * [ ] Google Pixel 2
  * [ ] Galaxy S8 Plus
  * [ ] Galaxy S7 Edge
  * [ ] Galaxy S6
  * [ ] iPhone 7+
  * [ ] iPhone 6

Accessibility Testing (If applicable)

* [ ] Text-to-Voice (Android: Voice Assistant / iOS: Speak Selection)
* [ ] Large Text (=<200%)
* [ ] Landscape Screen orientation

Weak connection testing (If applicable)

* [ ] Airplane mode
* [ ] 2G/3G Network Settings
