### PR TITLE
Disable broken nightly-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,13 +556,13 @@ workflows:
             branches:
               only:
                 - master
-  nightly-release:
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - test-nightly
+  # nightly-release:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 7 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - test-nightly


### PR DESCRIPTION
The nightly release has been failing for... years? Because of the missing XCode image. This disables it.